### PR TITLE
Qt5 improvements and a new feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ Makefile
 build
 tetzle
 *~
+*.pro.user

--- a/src/appearance_dialog.cpp
+++ b/src/appearance_dialog.cpp
@@ -73,6 +73,8 @@ AppearanceDialog::AppearanceDialog(QWidget* parent)
 	m_has_shadows = new QCheckBox(tr("Drop shadows"), options_group);
 	connect(m_has_shadows, &QCheckBox::stateChanged, this, &AppearanceDialog::updatePreview);
 
+	m_has_message = new QCheckBox(tr("Success message"), options_group);
+
 	// Create colors widgets
 	QGroupBox* colors_group = new QGroupBox(tr("Colors"), this);
 
@@ -100,6 +102,7 @@ AppearanceDialog::AppearanceDialog(QWidget* parent)
 	QVBoxLayout* options_layout = new QVBoxLayout(options_group);
 	options_layout->addWidget(m_has_bevels);
 	options_layout->addWidget(m_has_shadows);
+	options_layout->addWidget(m_has_message);
 
 	QGridLayout* layout = new QGridLayout(this);
 	layout->setSpacing(12);
@@ -118,6 +121,7 @@ AppearanceDialog::AppearanceDialog(QWidget* parent)
 	m_highlight->setColor(settings.value("Colors/Highlight", QColor(Qt::white)).value<QColor>());
 	m_has_bevels->setChecked(settings.value("Appearance/Bevels", true).toBool());
 	m_has_shadows->setChecked(settings.value("Appearance/Shadows", true).toBool());
+	m_has_message->setChecked(settings.value("Appearance/Message", true).toBool());
 	if (!m_bevels_enabled) {
 		m_has_bevels->setChecked(false);
 		m_has_bevels->setEnabled(false);
@@ -137,6 +141,13 @@ bool AppearanceDialog::hasBevels() const
 bool AppearanceDialog::hasShadows() const
 {
 	return m_has_shadows->isChecked();
+}
+
+//-----------------------------------------------------------------------------
+
+bool AppearanceDialog::hasMessage() const
+{
+	return m_has_message->isChecked();
 }
 
 //-----------------------------------------------------------------------------
@@ -167,6 +178,7 @@ void AppearanceDialog::accept()
 	settings.setValue("Colors/Highlight", m_highlight->color());
 	settings.setValue("Appearance/Bevels", m_has_bevels->isChecked());
 	settings.setValue("Appearance/Shadows", m_has_shadows->isChecked());
+	settings.setValue("Appearance/Message", m_has_message->isChecked());
 	QDialog::accept();
 }
 

--- a/src/appearance_dialog.h
+++ b/src/appearance_dialog.h
@@ -34,6 +34,7 @@ public:
 
 	bool hasBevels() const;
 	bool hasShadows() const;
+	bool hasMessage() const;
 	QPalette colors() const;
 
 	static void setBevelsEnabled(bool enabled);
@@ -48,6 +49,7 @@ private slots:
 private:
 	QCheckBox* m_has_bevels;
 	QCheckBox* m_has_shadows;
+	QCheckBox* m_has_message;
 	ColorButton* m_background;
 	ColorButton* m_shadow;
 	ColorButton* m_highlight;

--- a/src/board.cpp
+++ b/src/board.cpp
@@ -91,6 +91,7 @@ Board::Board(QWidget* parent)
 	m_load_bevels(true),
 	m_has_bevels(true),
 	m_has_shadows(true),
+	m_has_message(true),
 	m_image(0),
 	m_image_ts(0),
 	m_columns(0),
@@ -157,6 +158,7 @@ void Board::setAppearance(const AppearanceDialog& dialog)
 {
 	m_has_bevels = dialog.hasBevels();
 	m_has_shadows = dialog.hasShadows();
+	m_has_message = dialog.hasMessage();
 
 	QPalette palette = dialog.colors();
 	qglClearColor(palette.color(QPalette::Base).darker(150));
@@ -1325,8 +1327,10 @@ void Board::finishGame()
 
 	emit finished();
 
-	m_message->setText(tr("Success"));
-	m_message->setVisible(true);
+	if (m_has_message) {
+		m_message->setText(tr("Success"));
+		m_message->setVisible(true);
+	}
 }
 
 //-----------------------------------------------------------------------------

--- a/src/board.cpp
+++ b/src/board.cpp
@@ -244,7 +244,7 @@ void Board::newGame(const QString& image, int difficulty)
 		// Show pieces
 		if ((i % step) == 0) {
 			m_pos = m_scene.center();
-			updateGL();
+			update();
 			updateStatusMessage(tr("Creating pieces..."));
 		}
 	}
@@ -519,7 +519,7 @@ void Board::zoomFit()
 
 	m_pos = m_scene.center();
 	if (m_scale_level == level) {
-		updateGL();
+		update();
 		return;
 	}
 
@@ -550,7 +550,7 @@ void Board::zoom(int level)
 	updateCursor();
 
 	// Update scene
-	updateGL();
+	update();
 	emit zoomChanged(m_scale_level, m_scale);
 	emit zoomOutAvailable(m_scale_level > 0);
 	emit zoomInAvailable(m_scale_level < 9);
@@ -701,28 +701,28 @@ void Board::keyPressEvent(QKeyEvent* event)
 	// Scroll left
 	case Qt::Key_Left:
 		scroll(QPoint(2 * offset, 0));
-		updateGL();
+		update();
 		updateCursor();
 		break;
 
 	// Scroll up
 	case Qt::Key_Up:
 		scroll(QPoint(0, 2 * offset));
-		updateGL();
+		update();
 		updateCursor();
 		break;
 
 	// Scroll right
 	case Qt::Key_Right:
 		scroll(QPoint(-2 * offset, 0));
-		updateGL();
+		update();
 		updateCursor();
 		break;
 
 	// Scroll down
 	case Qt::Key_Down:
 		scroll(QPoint(0, -2 * offset));
-		updateGL();
+		update();
 		updateCursor();
 		break;
 
@@ -877,7 +877,7 @@ void Board::mouseMoveEvent(QMouseEvent* event)
 		updateArray(m_selection_array, QRect(event->pos(), m_select_pos).normalized(), 3000);
 	}
 
-	updateGL();
+	update();
 
 	m_cursor_pos = event->pos();
 
@@ -985,7 +985,7 @@ void Board::grabPiece()
 	piece->setSelected(true);
 	updateCursor();
 
-	updateGL();
+	update();
 }
 
 //-----------------------------------------------------------------------------
@@ -1029,7 +1029,7 @@ void Board::releasePieces()
 	if (pieceCount() == 1) {
 		finishGame();
 	} else {
-		updateGL();
+		update();
 	}
 }
 
@@ -1061,7 +1061,7 @@ void Board::rotatePiece()
 		finishGame();
 	}
 
-	updateGL();
+	update();
 }
 
 //-----------------------------------------------------------------------------
@@ -1083,7 +1083,7 @@ void Board::selectPieces()
 	m_active_pieces += m_selected_pieces;
 	m_selected_pieces.clear();
 
-	updateGL();
+	update();
 	updateCursor();
 }
 

--- a/src/board.h
+++ b/src/board.h
@@ -117,6 +117,7 @@ private:
 	Message* m_message;
 	bool m_has_bevels;
 	bool m_has_shadows;
+	bool m_has_message;
 
 	GLuint m_image;
 	GLuint m_bumpmap_image;

--- a/translations/tetzle_cs.ts
+++ b/translations/tetzle_cs.ts
@@ -4,7 +4,7 @@
 <context>
     <name>AddImage</name>
     <message>
-        <location filename="../src/add_image.cpp" line="87"/>
+        <location filename="../src/add_image.cpp" line="79"/>
         <source>Open Image</source>
         <translation>Otevřít obrázek</translation>
     </message>
@@ -32,22 +32,27 @@
         <translation>Stíny</translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="77"/>
+        <location filename="../src/appearance_dialog.cpp" line="76"/>
+        <source>Success message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/appearance_dialog.cpp" line="79"/>
         <source>Colors</source>
         <translation>Barvy</translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="96"/>
+        <location filename="../src/appearance_dialog.cpp" line="98"/>
         <source>Background:</source>
         <translation>Pozadí:</translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="97"/>
+        <location filename="../src/appearance_dialog.cpp" line="99"/>
         <source>Shadow:</source>
         <translation>Stín:</translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="98"/>
+        <location filename="../src/appearance_dialog.cpp" line="100"/>
         <source>Highlight:</source>
         <translation>Zvýraznění:</translation>
     </message>
@@ -55,59 +60,59 @@
 <context>
     <name>Board</name>
     <message>
-        <location filename="../src/board.cpp" line="187"/>
-        <location filename="../src/board.cpp" line="293"/>
-        <location filename="../src/board.cpp" line="361"/>
+        <location filename="../src/board.cpp" line="190"/>
+        <location filename="../src/board.cpp" line="301"/>
+        <location filename="../src/board.cpp" line="369"/>
         <source>Error</source>
         <translation>Chyba</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="187"/>
-        <location filename="../src/board.cpp" line="293"/>
+        <location filename="../src/board.cpp" line="190"/>
+        <location filename="../src/board.cpp" line="301"/>
         <source>Missing image.</source>
         <translation>Chybějící obrázek.</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="194"/>
-        <location filename="../src/board.cpp" line="269"/>
-        <location filename="../src/main.cpp" line="167"/>
+        <location filename="../src/board.cpp" line="197"/>
+        <location filename="../src/board.cpp" line="277"/>
+        <location filename="../src/main.cpp" line="162"/>
         <source>Please Wait</source>
         <translation>Prosím čekejte</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="216"/>
-        <location filename="../src/board.cpp" line="368"/>
+        <location filename="../src/board.cpp" line="219"/>
+        <location filename="../src/board.cpp" line="376"/>
         <source>Loading image...</source>
         <translation>Nahrávání obrázku…</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="222"/>
+        <location filename="../src/board.cpp" line="225"/>
         <source>Generating puzzle...</source>
         <translation>Vytváření skládanky…</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="228"/>
-        <location filename="../src/board.cpp" line="242"/>
+        <location filename="../src/board.cpp" line="236"/>
+        <location filename="../src/board.cpp" line="250"/>
         <source>Creating pieces...</source>
         <translation>Vytváření dílů…</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="281"/>
+        <location filename="../src/board.cpp" line="289"/>
         <source>Loading puzzle...</source>
         <translation>Nahrávání skládanky…</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="306"/>
+        <location filename="../src/board.cpp" line="314"/>
         <source>Unknown data format</source>
         <translation>Neznámý formát dat</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="356"/>
+        <location filename="../src/board.cpp" line="364"/>
         <source>Unknown element &apos;%1&apos;</source>
         <translation>Neznámý prvek „%1“</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="361"/>
+        <location filename="../src/board.cpp" line="369"/>
         <source>Error parsing XML file.
 
 %1</source>
@@ -116,22 +121,22 @@
 %1</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="372"/>
+        <location filename="../src/board.cpp" line="380"/>
         <source>Loading pieces...</source>
         <translation>Nahrávání dílů…</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="454"/>
+        <location filename="../src/board.cpp" line="462"/>
         <source>Retrieving pieces...</source>
         <translation>Shromažďování dílů…</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="994"/>
+        <location filename="../src/board.cpp" line="1002"/>
         <source>Placing pieces...</source>
         <translation>Rozmisťování dílů…</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="1326"/>
+        <location filename="../src/board.cpp" line="1331"/>
         <source>Success</source>
         <translation>Úspěch</translation>
     </message>
@@ -175,22 +180,22 @@
 <context>
     <name>LocaleDialog</name>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="50"/>
+        <location filename="../src/locale_dialog.cpp" line="52"/>
         <source>Select application language:</source>
         <translation>Vyberte jazyk aplikace:</translation>
     </message>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="53"/>
+        <location filename="../src/locale_dialog.cpp" line="55"/>
         <source>&lt;System Language&gt;</source>
         <translation>Systémový jazyk</translation>
     </message>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="183"/>
+        <location filename="../src/locale_dialog.cpp" line="172"/>
         <source>Note</source>
         <translation>Poznámka</translation>
     </message>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="183"/>
+        <location filename="../src/locale_dialog.cpp" line="172"/>
         <source>Please restart this application for the change in language to take effect.</source>
         <translation>Pro uplatnění změn v nastavení jazyka prosím ukončete a znovu spusťte aplikaci.</translation>
     </message>
@@ -198,44 +203,44 @@
 <context>
     <name>NewGameTab</name>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="105"/>
+        <location filename="../src/new_game_tab.cpp" line="106"/>
         <source>Add Image</source>
         <translation>Přidat obrázek</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="109"/>
-        <location filename="../src/new_game_tab.cpp" line="290"/>
+        <location filename="../src/new_game_tab.cpp" line="110"/>
+        <location filename="../src/new_game_tab.cpp" line="291"/>
         <source>Remove Image</source>
         <translation>Odstranit obrázek</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="113"/>
+        <location filename="../src/new_game_tab.cpp" line="114"/>
         <source>Image Properties</source>
         <translation>Vlastnosti obrázku</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="132"/>
-        <location filename="../src/new_game_tab.cpp" line="383"/>
+        <location filename="../src/new_game_tab.cpp" line="133"/>
+        <location filename="../src/new_game_tab.cpp" line="384"/>
         <source>%L1 pieces</source>
         <translation>%L1 dílů</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="193"/>
+        <location filename="../src/new_game_tab.cpp" line="194"/>
         <source>Copying images...</source>
         <translation>Kopírování obrázků…</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="193"/>
+        <location filename="../src/new_game_tab.cpp" line="194"/>
         <source>Cancel</source>
         <translation>Zrušit</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="286"/>
+        <location filename="../src/new_game_tab.cpp" line="287"/>
         <source>Remove selected image?</source>
         <translation>Odstranit vybraný obrázek?</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="288"/>
+        <location filename="../src/new_game_tab.cpp" line="289"/>
         <source>Remove selected image?
 
 There are saved games using this image that will also be removed.</source>
@@ -244,7 +249,7 @@ There are saved games using this image that will also be removed.</source>
 Některé z rozehraných her používají tento obrázek, odstraníte-li jej, budou taktéž odstraněny.</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="493"/>
+        <location filename="../src/new_game_tab.cpp" line="494"/>
         <source>Untitled</source>
         <translation>Nepojmenovaný</translation>
     </message>
@@ -280,7 +285,7 @@ Některé z rozehraných her používají tento obrázek, odstraníte-li jej, bu
 <context>
     <name>Overview</name>
     <message>
-        <location filename="../src/overview.cpp" line="38"/>
+        <location filename="../src/overview.cpp" line="39"/>
         <source>Overview</source>
         <translation>Náhled</translation>
     </message>
@@ -336,215 +341,215 @@ Některé z rozehraných her používají tento obrázek, odstraníte-li jej, bu
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/main.cpp" line="168"/>
-        <location filename="../src/window.cpp" line="50"/>
-        <location filename="../src/window.cpp" line="286"/>
+        <location filename="../src/main.cpp" line="56"/>
+        <location filename="../src/main.cpp" line="163"/>
+        <location filename="../src/window.cpp" line="283"/>
         <source>Tetzle</source>
         <translation>Tetzle</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="80"/>
+        <location filename="../src/window.cpp" line="79"/>
         <source>&amp;Game</source>
         <translation>&amp;Hra</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="84"/>
+        <location filename="../src/window.cpp" line="83"/>
         <source>&amp;Retrieve Pieces</source>
         <translation>&amp;Shromáždit díly</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="84"/>
+        <location filename="../src/window.cpp" line="83"/>
         <source>Ctrl+R</source>
         <translation>Ctrl+R</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="88"/>
+        <location filename="../src/window.cpp" line="87"/>
         <source>&amp;Quit</source>
         <translation>&amp;Ukončit</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="81"/>
+        <location filename="../src/window.cpp" line="80"/>
         <source>&amp;Choose...</source>
         <translation>&amp;Vybrat…</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="91"/>
+        <location filename="../src/window.cpp" line="90"/>
         <source>&amp;View</source>
         <translation>&amp;Zobrazit</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="92"/>
+        <location filename="../src/window.cpp" line="91"/>
         <source>Zoom &amp;In</source>
         <translation>&amp;Přiblížit</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="92"/>
+        <location filename="../src/window.cpp" line="91"/>
         <source>+</source>
         <translation>+</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="95"/>
+        <location filename="../src/window.cpp" line="94"/>
         <source>Zoom &amp;Out</source>
         <translation>&amp;Oddálit</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="95"/>
+        <location filename="../src/window.cpp" line="94"/>
         <source>-</source>
         <translation>-</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="98"/>
+        <location filename="../src/window.cpp" line="97"/>
         <source>Best &amp;Fit</source>
         <translation>O&amp;ptimální zobrazení</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="101"/>
+        <location filename="../src/window.cpp" line="100"/>
         <source>Show O&amp;verview</source>
         <translation>&amp;Zobrazit náhled</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="101"/>
+        <location filename="../src/window.cpp" line="100"/>
         <source>Tab</source>
         <translation>Tab</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="107"/>
+        <location filename="../src/window.cpp" line="106"/>
         <source>F&amp;ullscreen</source>
         <translation>&amp;Celá obrazovka</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="111"/>
+        <location filename="../src/window.cpp" line="110"/>
         <source>F11</source>
         <translation>F11</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="113"/>
+        <location filename="../src/window.cpp" line="112"/>
         <source>Ctrl+F</source>
         <translation>Ctrl+F</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="116"/>
+        <location filename="../src/window.cpp" line="115"/>
         <source>&amp;Settings</source>
         <translation>&amp;Nastavení</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="117"/>
+        <location filename="../src/window.cpp" line="116"/>
         <source>&amp;Appearance...</source>
         <translation>&amp;Vzhled…</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="118"/>
+        <location filename="../src/window.cpp" line="117"/>
         <source>&amp;Language...</source>
         <translation>&amp;Jazyk…</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="120"/>
+        <location filename="../src/window.cpp" line="119"/>
         <source>&amp;Help</source>
         <translation>&amp;Nápověda</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="121"/>
+        <location filename="../src/window.cpp" line="120"/>
         <source>&amp;Controls</source>
         <translation>&amp;Ovládání</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="123"/>
+        <location filename="../src/window.cpp" line="122"/>
         <source>&amp;About</source>
         <translation>&amp;O aplikaci</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="125"/>
+        <location filename="../src/window.cpp" line="124"/>
         <source>About &amp;Qt</source>
         <translation>&amp;O Qt</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="252"/>
+        <location filename="../src/window.cpp" line="249"/>
         <source>Controls</source>
         <translation>Ovládání</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="259"/>
+        <location filename="../src/window.cpp" line="256"/>
         <source>&lt;b&gt;Pick Up Pieces:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Sebrání dílů:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="260"/>
-        <location filename="../src/window.cpp" line="262"/>
+        <location filename="../src/window.cpp" line="257"/>
+        <location filename="../src/window.cpp" line="259"/>
         <source>Left Click or Space</source>
         <translation>Levé tlačítko nebo mezerník</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="261"/>
+        <location filename="../src/window.cpp" line="258"/>
         <source>&lt;b&gt;Drop Pieces:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Položení dílů:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="263"/>
+        <location filename="../src/window.cpp" line="260"/>
         <source>&lt;b&gt;Select Pieces:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Výběr dílů:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="264"/>
+        <location filename="../src/window.cpp" line="261"/>
         <source>Left Drag</source>
         <translation>Tažení levým tlačítkem</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="265"/>
+        <location filename="../src/window.cpp" line="262"/>
         <source>&lt;b&gt;Rotate Pieces:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Pootočení dílů:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="266"/>
+        <location filename="../src/window.cpp" line="263"/>
         <source>Right Click, Control + Left Click, or R</source>
         <translation>Pravé tlačítko, Ctrl + Levé tlačítko, nebo R</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="267"/>
+        <location filename="../src/window.cpp" line="264"/>
         <source>&lt;b&gt;Drag Puzzle:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Přetažení skládanky:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="268"/>
+        <location filename="../src/window.cpp" line="265"/>
         <source>Middle Click, Shift + Left Click, or Arrows</source>
         <translation>Prostřední tlačítko, Shift + Levé tlačítko, nebo šipky</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="269"/>
+        <location filename="../src/window.cpp" line="266"/>
         <source>&lt;b&gt;Zoom Puzzle:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Úroveň přiblížení skládanky:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="270"/>
+        <location filename="../src/window.cpp" line="267"/>
         <source>Scrollwheel or +/-</source>
         <translation>Kolečko myši nebo +/-</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="271"/>
+        <location filename="../src/window.cpp" line="268"/>
         <source>&lt;b&gt;Move Cursor:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Pohyb kurzoru:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="272"/>
+        <location filename="../src/window.cpp" line="269"/>
         <source>Move mouse or W,A,D,S</source>
         <translation>Myš nebo W, A, D, S</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="285"/>
+        <location filename="../src/window.cpp" line="282"/>
         <source>About Tetzle</source>
         <translation>O Tetzle</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="287"/>
+        <location filename="../src/window.cpp" line="284"/>
         <source>A jigsaw puzzle with tetrominoes for pieces</source>
         <translation>Skládanka s díly ve tvaru tetromina</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="288"/>
+        <location filename="../src/window.cpp" line="285"/>
         <source>Copyright &amp;copy; 2008-%1 Graeme Gott</source>
         <translation>Copyright &amp;copy; 2008-%1 Graeme Gott</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="289"/>
+        <location filename="../src/window.cpp" line="286"/>
         <source>Released under the &lt;a href=%1&gt;GPL 3&lt;/a&gt; license</source>
         <translation>Vydáno pod licencí &lt;a href=%1&gt;GPL 3&lt;/a&gt;</translation>
     </message>
@@ -552,12 +557,12 @@ Některé z rozehraných her používají tento obrázek, odstraníte-li jej, bu
 <context>
     <name>ZoomSlider</name>
     <message>
-        <location filename="../src/zoom_slider.cpp" line="38"/>
+        <location filename="../src/zoom_slider.cpp" line="40"/>
         <source>??%</source>
         <translation>??%</translation>
     </message>
     <message>
-        <location filename="../src/zoom_slider.cpp" line="63"/>
+        <location filename="../src/zoom_slider.cpp" line="65"/>
         <source>%1%</source>
         <translation>%1%</translation>
     </message>

--- a/translations/tetzle_de.ts
+++ b/translations/tetzle_de.ts
@@ -4,7 +4,7 @@
 <context>
     <name>AddImage</name>
     <message>
-        <location filename="../src/add_image.cpp" line="87"/>
+        <location filename="../src/add_image.cpp" line="79"/>
         <source>Open Image</source>
         <translation>Bild auswählen</translation>
     </message>
@@ -32,22 +32,27 @@
         <translation>Schlagschatten</translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="77"/>
+        <location filename="../src/appearance_dialog.cpp" line="76"/>
+        <source>Success message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/appearance_dialog.cpp" line="79"/>
         <source>Colors</source>
         <translation>Farben</translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="96"/>
+        <location filename="../src/appearance_dialog.cpp" line="98"/>
         <source>Background:</source>
         <translation>Hintergrund:</translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="97"/>
+        <location filename="../src/appearance_dialog.cpp" line="99"/>
         <source>Shadow:</source>
         <translation>Schatten:</translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="98"/>
+        <location filename="../src/appearance_dialog.cpp" line="100"/>
         <source>Highlight:</source>
         <translation>Hervorgehoben:</translation>
     </message>
@@ -55,59 +60,59 @@
 <context>
     <name>Board</name>
     <message>
-        <location filename="../src/board.cpp" line="187"/>
-        <location filename="../src/board.cpp" line="293"/>
-        <location filename="../src/board.cpp" line="361"/>
+        <location filename="../src/board.cpp" line="190"/>
+        <location filename="../src/board.cpp" line="301"/>
+        <location filename="../src/board.cpp" line="369"/>
         <source>Error</source>
         <translation>Fehler</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="187"/>
-        <location filename="../src/board.cpp" line="293"/>
+        <location filename="../src/board.cpp" line="190"/>
+        <location filename="../src/board.cpp" line="301"/>
         <source>Missing image.</source>
         <translation>Bild nicht gefunden.</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="194"/>
-        <location filename="../src/board.cpp" line="269"/>
-        <location filename="../src/main.cpp" line="167"/>
+        <location filename="../src/board.cpp" line="197"/>
+        <location filename="../src/board.cpp" line="277"/>
+        <location filename="../src/main.cpp" line="162"/>
         <source>Please Wait</source>
         <translation>Bitte warten</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="216"/>
-        <location filename="../src/board.cpp" line="368"/>
+        <location filename="../src/board.cpp" line="219"/>
+        <location filename="../src/board.cpp" line="376"/>
         <source>Loading image...</source>
         <translation>Bild wird geladen...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="222"/>
+        <location filename="../src/board.cpp" line="225"/>
         <source>Generating puzzle...</source>
         <translation>Puzzle wird erzeugt...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="228"/>
-        <location filename="../src/board.cpp" line="242"/>
+        <location filename="../src/board.cpp" line="236"/>
+        <location filename="../src/board.cpp" line="250"/>
         <source>Creating pieces...</source>
         <translation>Teile werden erzeugt...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="281"/>
+        <location filename="../src/board.cpp" line="289"/>
         <source>Loading puzzle...</source>
         <translation>Puzzle wird geladen...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="306"/>
+        <location filename="../src/board.cpp" line="314"/>
         <source>Unknown data format</source>
         <translation>Unbekanntes Dateiformat</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="356"/>
+        <location filename="../src/board.cpp" line="364"/>
         <source>Unknown element &apos;%1&apos;</source>
         <translation>Unbekanntes Element &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="361"/>
+        <location filename="../src/board.cpp" line="369"/>
         <source>Error parsing XML file.
 
 %1</source>
@@ -116,22 +121,22 @@
 %1</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="372"/>
+        <location filename="../src/board.cpp" line="380"/>
         <source>Loading pieces...</source>
         <translation>Teile werden geladen...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="454"/>
+        <location filename="../src/board.cpp" line="462"/>
         <source>Retrieving pieces...</source>
         <translation>Teile werden geholt...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="994"/>
+        <location filename="../src/board.cpp" line="1002"/>
         <source>Placing pieces...</source>
         <translation>Teile werden gelegt...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="1326"/>
+        <location filename="../src/board.cpp" line="1331"/>
         <source>Success</source>
         <translation>Fertiggestellt</translation>
     </message>
@@ -175,22 +180,22 @@
 <context>
     <name>LocaleDialog</name>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="50"/>
+        <location filename="../src/locale_dialog.cpp" line="52"/>
         <source>Select application language:</source>
         <translation>Anwendungssprache auswählen:</translation>
     </message>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="53"/>
+        <location filename="../src/locale_dialog.cpp" line="55"/>
         <source>&lt;System Language&gt;</source>
         <translation>&lt;Systemeinstellung&gt;</translation>
     </message>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="183"/>
+        <location filename="../src/locale_dialog.cpp" line="172"/>
         <source>Note</source>
         <translation>Hinweis</translation>
     </message>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="183"/>
+        <location filename="../src/locale_dialog.cpp" line="172"/>
         <source>Please restart this application for the change in language to take effect.</source>
         <translation>Bitte starten Sie diese Anwendung neu um den Wechsel der Sprache auszuführen.</translation>
     </message>
@@ -198,44 +203,44 @@
 <context>
     <name>NewGameTab</name>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="105"/>
+        <location filename="../src/new_game_tab.cpp" line="106"/>
         <source>Add Image</source>
         <translation>Bild hinzufügen</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="109"/>
-        <location filename="../src/new_game_tab.cpp" line="290"/>
+        <location filename="../src/new_game_tab.cpp" line="110"/>
+        <location filename="../src/new_game_tab.cpp" line="291"/>
         <source>Remove Image</source>
         <translation>Bild entfernen</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="113"/>
+        <location filename="../src/new_game_tab.cpp" line="114"/>
         <source>Image Properties</source>
         <translation>Bildeigenschaften</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="132"/>
-        <location filename="../src/new_game_tab.cpp" line="383"/>
+        <location filename="../src/new_game_tab.cpp" line="133"/>
+        <location filename="../src/new_game_tab.cpp" line="384"/>
         <source>%L1 pieces</source>
         <translation>%L1 Teile</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="193"/>
+        <location filename="../src/new_game_tab.cpp" line="194"/>
         <source>Copying images...</source>
         <translation>Bilder werden kopiert...</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="193"/>
+        <location filename="../src/new_game_tab.cpp" line="194"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="286"/>
+        <location filename="../src/new_game_tab.cpp" line="287"/>
         <source>Remove selected image?</source>
         <translation>Ausgewähltes Bild entfernen?</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="288"/>
+        <location filename="../src/new_game_tab.cpp" line="289"/>
         <source>Remove selected image?
 
 There are saved games using this image that will also be removed.</source>
@@ -244,7 +249,7 @@ There are saved games using this image that will also be removed.</source>
 Es existieren gespeicherte Spiele, die dieses Bild benutzen und die ebenfalls gelöscht werden.</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="493"/>
+        <location filename="../src/new_game_tab.cpp" line="494"/>
         <source>Untitled</source>
         <translation>Unbenannt</translation>
     </message>
@@ -280,7 +285,7 @@ Es existieren gespeicherte Spiele, die dieses Bild benutzen und die ebenfalls ge
 <context>
     <name>Overview</name>
     <message>
-        <location filename="../src/overview.cpp" line="38"/>
+        <location filename="../src/overview.cpp" line="39"/>
         <source>Overview</source>
         <translation>Übersicht</translation>
     </message>
@@ -336,215 +341,215 @@ Es existieren gespeicherte Spiele, die dieses Bild benutzen und die ebenfalls ge
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/main.cpp" line="168"/>
-        <location filename="../src/window.cpp" line="50"/>
-        <location filename="../src/window.cpp" line="286"/>
+        <location filename="../src/main.cpp" line="56"/>
+        <location filename="../src/main.cpp" line="163"/>
+        <location filename="../src/window.cpp" line="283"/>
         <source>Tetzle</source>
         <translation>Tetzle</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="80"/>
+        <location filename="../src/window.cpp" line="79"/>
         <source>&amp;Game</source>
         <translation>&amp;Spiel</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="84"/>
+        <location filename="../src/window.cpp" line="83"/>
         <source>&amp;Retrieve Pieces</source>
         <translation>&amp;Teile holen</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="84"/>
+        <location filename="../src/window.cpp" line="83"/>
         <source>Ctrl+R</source>
         <translation>Ctrl+T</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="88"/>
+        <location filename="../src/window.cpp" line="87"/>
         <source>&amp;Quit</source>
         <translation>&amp;Beenden</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="81"/>
+        <location filename="../src/window.cpp" line="80"/>
         <source>&amp;Choose...</source>
         <translation>&amp;Auswählen...</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="91"/>
+        <location filename="../src/window.cpp" line="90"/>
         <source>&amp;View</source>
         <translation>&amp;Ansicht</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="92"/>
+        <location filename="../src/window.cpp" line="91"/>
         <source>Zoom &amp;In</source>
         <translation>Ver&amp;größern</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="92"/>
+        <location filename="../src/window.cpp" line="91"/>
         <source>+</source>
         <translation>+</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="95"/>
+        <location filename="../src/window.cpp" line="94"/>
         <source>Zoom &amp;Out</source>
         <translation>Ver&amp;kleinern</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="95"/>
+        <location filename="../src/window.cpp" line="94"/>
         <source>-</source>
         <translation>-</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="98"/>
+        <location filename="../src/window.cpp" line="97"/>
         <source>Best &amp;Fit</source>
         <translation>In Fenster &amp;einpassen</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="101"/>
+        <location filename="../src/window.cpp" line="100"/>
         <source>Show O&amp;verview</source>
         <translation>Ü&amp;bersicht zeigen</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="101"/>
+        <location filename="../src/window.cpp" line="100"/>
         <source>Tab</source>
         <translation>Tab</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="107"/>
+        <location filename="../src/window.cpp" line="106"/>
         <source>F&amp;ullscreen</source>
         <translation>&amp;Vollbild</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="111"/>
+        <location filename="../src/window.cpp" line="110"/>
         <source>F11</source>
         <translation>F11</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="113"/>
+        <location filename="../src/window.cpp" line="112"/>
         <source>Ctrl+F</source>
         <translation>Ctrl+F</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="116"/>
+        <location filename="../src/window.cpp" line="115"/>
         <source>&amp;Settings</source>
         <translation>&amp;Einstellungen</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="117"/>
+        <location filename="../src/window.cpp" line="116"/>
         <source>&amp;Appearance...</source>
         <translation>&amp;Erscheinungsbild...</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="118"/>
+        <location filename="../src/window.cpp" line="117"/>
         <source>&amp;Language...</source>
         <translation>&amp;Sprache...</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="120"/>
+        <location filename="../src/window.cpp" line="119"/>
         <source>&amp;Help</source>
         <translation>&amp;Hilfe</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="121"/>
+        <location filename="../src/window.cpp" line="120"/>
         <source>&amp;Controls</source>
         <translation>&amp;Steuerung</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="123"/>
+        <location filename="../src/window.cpp" line="122"/>
         <source>&amp;About</source>
         <translation>Ü&amp;ber</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="125"/>
+        <location filename="../src/window.cpp" line="124"/>
         <source>About &amp;Qt</source>
         <translation>Über &amp;Qt</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="252"/>
+        <location filename="../src/window.cpp" line="249"/>
         <source>Controls</source>
         <translation>Steuerung</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="259"/>
+        <location filename="../src/window.cpp" line="256"/>
         <source>&lt;b&gt;Pick Up Pieces:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Teile aufnehmen:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="260"/>
-        <location filename="../src/window.cpp" line="262"/>
+        <location filename="../src/window.cpp" line="257"/>
+        <location filename="../src/window.cpp" line="259"/>
         <source>Left Click or Space</source>
         <translation>Linksklick oder Leertaste</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="261"/>
+        <location filename="../src/window.cpp" line="258"/>
         <source>&lt;b&gt;Drop Pieces:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Teile ablegen:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="263"/>
+        <location filename="../src/window.cpp" line="260"/>
         <source>&lt;b&gt;Select Pieces:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Teile auswählen:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="264"/>
+        <location filename="../src/window.cpp" line="261"/>
         <source>Left Drag</source>
         <translation>Ziehen mit linker Maustaste</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="265"/>
+        <location filename="../src/window.cpp" line="262"/>
         <source>&lt;b&gt;Rotate Pieces:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Teile drehen:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="266"/>
+        <location filename="../src/window.cpp" line="263"/>
         <source>Right Click, Control + Left Click, or R</source>
         <translation>Rechtsklick, Strg + Linksklick, oder R</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="267"/>
+        <location filename="../src/window.cpp" line="264"/>
         <source>&lt;b&gt;Drag Puzzle:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Puzzle verschieben:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="268"/>
+        <location filename="../src/window.cpp" line="265"/>
         <source>Middle Click, Shift + Left Click, or Arrows</source>
         <translation>Mittelklick, Umschalt + Linksklick, oder Pfeiltasten</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="269"/>
+        <location filename="../src/window.cpp" line="266"/>
         <source>&lt;b&gt;Zoom Puzzle:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Puzzlegröße ändern:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="270"/>
+        <location filename="../src/window.cpp" line="267"/>
         <source>Scrollwheel or +/-</source>
         <translation>Mausrad oder +/-</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="271"/>
+        <location filename="../src/window.cpp" line="268"/>
         <source>&lt;b&gt;Move Cursor:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Zeiger bewegen:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="272"/>
+        <location filename="../src/window.cpp" line="269"/>
         <source>Move mouse or W,A,D,S</source>
         <translation>Maus bewegen oder W, A, D, S</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="285"/>
+        <location filename="../src/window.cpp" line="282"/>
         <source>About Tetzle</source>
         <translation>Über Tetzle</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="287"/>
+        <location filename="../src/window.cpp" line="284"/>
         <source>A jigsaw puzzle with tetrominoes for pieces</source>
         <translation>Ein Puzzlespiel mit Tetrominos als Puzzleteile</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="288"/>
+        <location filename="../src/window.cpp" line="285"/>
         <source>Copyright &amp;copy; 2008-%1 Graeme Gott</source>
         <translation>Copyright &amp;copy; 2008-%1 Graeme Gott</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="289"/>
+        <location filename="../src/window.cpp" line="286"/>
         <source>Released under the &lt;a href=%1&gt;GPL 3&lt;/a&gt; license</source>
         <translation>Veröffentlicht unter der &lt;a href=%1&gt;GPL-3&lt;/a&gt;-Lizenz</translation>
     </message>
@@ -552,12 +557,12 @@ Es existieren gespeicherte Spiele, die dieses Bild benutzen und die ebenfalls ge
 <context>
     <name>ZoomSlider</name>
     <message>
-        <location filename="../src/zoom_slider.cpp" line="38"/>
+        <location filename="../src/zoom_slider.cpp" line="40"/>
         <source>??%</source>
         <translation>??%</translation>
     </message>
     <message>
-        <location filename="../src/zoom_slider.cpp" line="63"/>
+        <location filename="../src/zoom_slider.cpp" line="65"/>
         <source>%1%</source>
         <translation>%1%</translation>
     </message>

--- a/translations/tetzle_en.ts
+++ b/translations/tetzle_en.ts
@@ -4,7 +4,7 @@
 <context>
     <name>AddImage</name>
     <message>
-        <location filename="../src/add_image.cpp" line="87"/>
+        <location filename="../src/add_image.cpp" line="79"/>
         <source>Open Image</source>
         <translation type="unfinished"></translation>
     </message>
@@ -32,22 +32,27 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="77"/>
+        <location filename="../src/appearance_dialog.cpp" line="76"/>
+        <source>Success message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/appearance_dialog.cpp" line="79"/>
         <source>Colors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="96"/>
+        <location filename="../src/appearance_dialog.cpp" line="98"/>
         <source>Background:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="97"/>
+        <location filename="../src/appearance_dialog.cpp" line="99"/>
         <source>Shadow:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="98"/>
+        <location filename="../src/appearance_dialog.cpp" line="100"/>
         <source>Highlight:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -55,81 +60,81 @@
 <context>
     <name>Board</name>
     <message>
-        <location filename="../src/board.cpp" line="187"/>
-        <location filename="../src/board.cpp" line="293"/>
-        <location filename="../src/board.cpp" line="361"/>
+        <location filename="../src/board.cpp" line="190"/>
+        <location filename="../src/board.cpp" line="301"/>
+        <location filename="../src/board.cpp" line="369"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="187"/>
-        <location filename="../src/board.cpp" line="293"/>
+        <location filename="../src/board.cpp" line="190"/>
+        <location filename="../src/board.cpp" line="301"/>
         <source>Missing image.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="194"/>
-        <location filename="../src/board.cpp" line="269"/>
-        <location filename="../src/main.cpp" line="167"/>
+        <location filename="../src/board.cpp" line="197"/>
+        <location filename="../src/board.cpp" line="277"/>
+        <location filename="../src/main.cpp" line="162"/>
         <source>Please Wait</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="216"/>
-        <location filename="../src/board.cpp" line="368"/>
+        <location filename="../src/board.cpp" line="219"/>
+        <location filename="../src/board.cpp" line="376"/>
         <source>Loading image...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="222"/>
+        <location filename="../src/board.cpp" line="225"/>
         <source>Generating puzzle...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="228"/>
-        <location filename="../src/board.cpp" line="242"/>
+        <location filename="../src/board.cpp" line="236"/>
+        <location filename="../src/board.cpp" line="250"/>
         <source>Creating pieces...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="281"/>
+        <location filename="../src/board.cpp" line="289"/>
         <source>Loading puzzle...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="306"/>
+        <location filename="../src/board.cpp" line="314"/>
         <source>Unknown data format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="356"/>
+        <location filename="../src/board.cpp" line="364"/>
         <source>Unknown element &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="361"/>
+        <location filename="../src/board.cpp" line="369"/>
         <source>Error parsing XML file.
 
 %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="372"/>
+        <location filename="../src/board.cpp" line="380"/>
         <source>Loading pieces...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="454"/>
+        <location filename="../src/board.cpp" line="462"/>
         <source>Retrieving pieces...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="994"/>
+        <location filename="../src/board.cpp" line="1002"/>
         <source>Placing pieces...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="1326"/>
+        <location filename="../src/board.cpp" line="1331"/>
         <source>Success</source>
         <translation type="unfinished"></translation>
     </message>
@@ -173,22 +178,22 @@
 <context>
     <name>LocaleDialog</name>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="50"/>
+        <location filename="../src/locale_dialog.cpp" line="52"/>
         <source>Select application language:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="53"/>
+        <location filename="../src/locale_dialog.cpp" line="55"/>
         <source>&lt;System Language&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="183"/>
+        <location filename="../src/locale_dialog.cpp" line="172"/>
         <source>Note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="183"/>
+        <location filename="../src/locale_dialog.cpp" line="172"/>
         <source>Please restart this application for the change in language to take effect.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -196,51 +201,51 @@
 <context>
     <name>NewGameTab</name>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="105"/>
+        <location filename="../src/new_game_tab.cpp" line="106"/>
         <source>Add Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="109"/>
-        <location filename="../src/new_game_tab.cpp" line="290"/>
+        <location filename="../src/new_game_tab.cpp" line="110"/>
+        <location filename="../src/new_game_tab.cpp" line="291"/>
         <source>Remove Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="113"/>
+        <location filename="../src/new_game_tab.cpp" line="114"/>
         <source>Image Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="132"/>
-        <location filename="../src/new_game_tab.cpp" line="383"/>
+        <location filename="../src/new_game_tab.cpp" line="133"/>
+        <location filename="../src/new_game_tab.cpp" line="384"/>
         <source>%L1 pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="193"/>
+        <location filename="../src/new_game_tab.cpp" line="194"/>
         <source>Copying images...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="193"/>
+        <location filename="../src/new_game_tab.cpp" line="194"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="286"/>
+        <location filename="../src/new_game_tab.cpp" line="287"/>
         <source>Remove selected image?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="288"/>
+        <location filename="../src/new_game_tab.cpp" line="289"/>
         <source>Remove selected image?
 
 There are saved games using this image that will also be removed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="493"/>
+        <location filename="../src/new_game_tab.cpp" line="494"/>
         <source>Untitled</source>
         <translation type="unfinished"></translation>
     </message>
@@ -276,7 +281,7 @@ There are saved games using this image that will also be removed.</source>
 <context>
     <name>Overview</name>
     <message>
-        <location filename="../src/overview.cpp" line="38"/>
+        <location filename="../src/overview.cpp" line="39"/>
         <source>Overview</source>
         <translation type="unfinished"></translation>
     </message>
@@ -332,215 +337,215 @@ There are saved games using this image that will also be removed.</source>
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/main.cpp" line="168"/>
-        <location filename="../src/window.cpp" line="50"/>
-        <location filename="../src/window.cpp" line="286"/>
+        <location filename="../src/main.cpp" line="56"/>
+        <location filename="../src/main.cpp" line="163"/>
+        <location filename="../src/window.cpp" line="283"/>
         <source>Tetzle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="80"/>
+        <location filename="../src/window.cpp" line="79"/>
         <source>&amp;Game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="84"/>
+        <location filename="../src/window.cpp" line="83"/>
         <source>&amp;Retrieve Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="84"/>
+        <location filename="../src/window.cpp" line="83"/>
         <source>Ctrl+R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="88"/>
+        <location filename="../src/window.cpp" line="87"/>
         <source>&amp;Quit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="81"/>
+        <location filename="../src/window.cpp" line="80"/>
         <source>&amp;Choose...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="91"/>
+        <location filename="../src/window.cpp" line="90"/>
         <source>&amp;View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="92"/>
+        <location filename="../src/window.cpp" line="91"/>
         <source>Zoom &amp;In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="92"/>
+        <location filename="../src/window.cpp" line="91"/>
         <source>+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="95"/>
+        <location filename="../src/window.cpp" line="94"/>
         <source>Zoom &amp;Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="95"/>
+        <location filename="../src/window.cpp" line="94"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="98"/>
+        <location filename="../src/window.cpp" line="97"/>
         <source>Best &amp;Fit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="101"/>
+        <location filename="../src/window.cpp" line="100"/>
         <source>Show O&amp;verview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="101"/>
+        <location filename="../src/window.cpp" line="100"/>
         <source>Tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="107"/>
+        <location filename="../src/window.cpp" line="106"/>
         <source>F&amp;ullscreen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="111"/>
+        <location filename="../src/window.cpp" line="110"/>
         <source>F11</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="113"/>
+        <location filename="../src/window.cpp" line="112"/>
         <source>Ctrl+F</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="116"/>
+        <location filename="../src/window.cpp" line="115"/>
         <source>&amp;Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="117"/>
+        <location filename="../src/window.cpp" line="116"/>
         <source>&amp;Appearance...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="118"/>
+        <location filename="../src/window.cpp" line="117"/>
         <source>&amp;Language...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="120"/>
+        <location filename="../src/window.cpp" line="119"/>
         <source>&amp;Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="121"/>
+        <location filename="../src/window.cpp" line="120"/>
         <source>&amp;Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="123"/>
+        <location filename="../src/window.cpp" line="122"/>
         <source>&amp;About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="125"/>
+        <location filename="../src/window.cpp" line="124"/>
         <source>About &amp;Qt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="252"/>
+        <location filename="../src/window.cpp" line="249"/>
         <source>Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="259"/>
+        <location filename="../src/window.cpp" line="256"/>
         <source>&lt;b&gt;Pick Up Pieces:&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="260"/>
-        <location filename="../src/window.cpp" line="262"/>
+        <location filename="../src/window.cpp" line="257"/>
+        <location filename="../src/window.cpp" line="259"/>
         <source>Left Click or Space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="261"/>
+        <location filename="../src/window.cpp" line="258"/>
         <source>&lt;b&gt;Drop Pieces:&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="263"/>
+        <location filename="../src/window.cpp" line="260"/>
         <source>&lt;b&gt;Select Pieces:&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="264"/>
+        <location filename="../src/window.cpp" line="261"/>
         <source>Left Drag</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="265"/>
+        <location filename="../src/window.cpp" line="262"/>
         <source>&lt;b&gt;Rotate Pieces:&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="266"/>
+        <location filename="../src/window.cpp" line="263"/>
         <source>Right Click, Control + Left Click, or R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="267"/>
+        <location filename="../src/window.cpp" line="264"/>
         <source>&lt;b&gt;Drag Puzzle:&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="268"/>
+        <location filename="../src/window.cpp" line="265"/>
         <source>Middle Click, Shift + Left Click, or Arrows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="269"/>
+        <location filename="../src/window.cpp" line="266"/>
         <source>&lt;b&gt;Zoom Puzzle:&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="270"/>
+        <location filename="../src/window.cpp" line="267"/>
         <source>Scrollwheel or +/-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="271"/>
+        <location filename="../src/window.cpp" line="268"/>
         <source>&lt;b&gt;Move Cursor:&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="272"/>
+        <location filename="../src/window.cpp" line="269"/>
         <source>Move mouse or W,A,D,S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="285"/>
+        <location filename="../src/window.cpp" line="282"/>
         <source>About Tetzle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="287"/>
+        <location filename="../src/window.cpp" line="284"/>
         <source>A jigsaw puzzle with tetrominoes for pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="288"/>
+        <location filename="../src/window.cpp" line="285"/>
         <source>Copyright &amp;copy; 2008-%1 Graeme Gott</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="289"/>
+        <location filename="../src/window.cpp" line="286"/>
         <source>Released under the &lt;a href=%1&gt;GPL 3&lt;/a&gt; license</source>
         <translation type="unfinished"></translation>
     </message>
@@ -548,12 +553,12 @@ There are saved games using this image that will also be removed.</source>
 <context>
     <name>ZoomSlider</name>
     <message>
-        <location filename="../src/zoom_slider.cpp" line="38"/>
+        <location filename="../src/zoom_slider.cpp" line="40"/>
         <source>??%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/zoom_slider.cpp" line="63"/>
+        <location filename="../src/zoom_slider.cpp" line="65"/>
         <source>%1%</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/tetzle_eo.ts
+++ b/translations/tetzle_eo.ts
@@ -4,7 +4,7 @@
 <context>
     <name>AddImage</name>
     <message>
-        <location filename="../src/add_image.cpp" line="87"/>
+        <location filename="../src/add_image.cpp" line="79"/>
         <source>Open Image</source>
         <translation>Malfermi bildon</translation>
     </message>
@@ -32,22 +32,27 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="77"/>
+        <location filename="../src/appearance_dialog.cpp" line="76"/>
+        <source>Success message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/appearance_dialog.cpp" line="79"/>
         <source>Colors</source>
         <translation>Koloroj</translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="96"/>
+        <location filename="../src/appearance_dialog.cpp" line="98"/>
         <source>Background:</source>
         <translation>Fono:</translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="97"/>
+        <location filename="../src/appearance_dialog.cpp" line="99"/>
         <source>Shadow:</source>
         <translation>Ombro:</translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="98"/>
+        <location filename="../src/appearance_dialog.cpp" line="100"/>
         <source>Highlight:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -55,59 +60,59 @@
 <context>
     <name>Board</name>
     <message>
-        <location filename="../src/board.cpp" line="187"/>
-        <location filename="../src/board.cpp" line="293"/>
-        <location filename="../src/board.cpp" line="361"/>
+        <location filename="../src/board.cpp" line="190"/>
+        <location filename="../src/board.cpp" line="301"/>
+        <location filename="../src/board.cpp" line="369"/>
         <source>Error</source>
         <translation>Eraro</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="187"/>
-        <location filename="../src/board.cpp" line="293"/>
+        <location filename="../src/board.cpp" line="190"/>
+        <location filename="../src/board.cpp" line="301"/>
         <source>Missing image.</source>
         <translation>Bildo mankas.</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="194"/>
-        <location filename="../src/board.cpp" line="269"/>
-        <location filename="../src/main.cpp" line="167"/>
+        <location filename="../src/board.cpp" line="197"/>
+        <location filename="../src/board.cpp" line="277"/>
+        <location filename="../src/main.cpp" line="162"/>
         <source>Please Wait</source>
         <translation>Bonvile atendu</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="216"/>
-        <location filename="../src/board.cpp" line="368"/>
+        <location filename="../src/board.cpp" line="219"/>
+        <location filename="../src/board.cpp" line="376"/>
         <source>Loading image...</source>
         <translation>Ŝargado de bildo...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="222"/>
+        <location filename="../src/board.cpp" line="225"/>
         <source>Generating puzzle...</source>
         <translation>Generado de puzlo...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="228"/>
-        <location filename="../src/board.cpp" line="242"/>
+        <location filename="../src/board.cpp" line="236"/>
+        <location filename="../src/board.cpp" line="250"/>
         <source>Creating pieces...</source>
         <translation>Kreado de eroj...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="281"/>
+        <location filename="../src/board.cpp" line="289"/>
         <source>Loading puzzle...</source>
         <translation>Ŝargado de puzlo...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="306"/>
+        <location filename="../src/board.cpp" line="314"/>
         <source>Unknown data format</source>
         <translation>Nekonata aranĝo de datumoj</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="356"/>
+        <location filename="../src/board.cpp" line="364"/>
         <source>Unknown element &apos;%1&apos;</source>
         <translation>Nekonata ero &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="361"/>
+        <location filename="../src/board.cpp" line="369"/>
         <source>Error parsing XML file.
 
 %1</source>
@@ -116,22 +121,22 @@
 %1</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="372"/>
+        <location filename="../src/board.cpp" line="380"/>
         <source>Loading pieces...</source>
         <translation>Ŝargado de eroj...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="454"/>
+        <location filename="../src/board.cpp" line="462"/>
         <source>Retrieving pieces...</source>
         <translation>Ricevado de eroj...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="994"/>
+        <location filename="../src/board.cpp" line="1002"/>
         <source>Placing pieces...</source>
         <translation>Metado de eroj...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="1326"/>
+        <location filename="../src/board.cpp" line="1331"/>
         <source>Success</source>
         <translation>Sukcese</translation>
     </message>
@@ -175,22 +180,22 @@
 <context>
     <name>LocaleDialog</name>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="50"/>
+        <location filename="../src/locale_dialog.cpp" line="52"/>
         <source>Select application language:</source>
         <translation>Elektu lingvon de alikaĵo:</translation>
     </message>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="53"/>
+        <location filename="../src/locale_dialog.cpp" line="55"/>
         <source>&lt;System Language&gt;</source>
         <translation>&lt;Lingvo de sistemo&gt;</translation>
     </message>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="183"/>
+        <location filename="../src/locale_dialog.cpp" line="172"/>
         <source>Note</source>
         <translation>Noto</translation>
     </message>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="183"/>
+        <location filename="../src/locale_dialog.cpp" line="172"/>
         <source>Please restart this application for the change in language to take effect.</source>
         <translation>Bonvole restartigu ĉi tiun aplikaĵon por efektivigi la ŝanĝon de lingvo.</translation>
     </message>
@@ -198,44 +203,44 @@
 <context>
     <name>NewGameTab</name>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="105"/>
+        <location filename="../src/new_game_tab.cpp" line="106"/>
         <source>Add Image</source>
         <translation>Aldoni bildon</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="109"/>
-        <location filename="../src/new_game_tab.cpp" line="290"/>
+        <location filename="../src/new_game_tab.cpp" line="110"/>
+        <location filename="../src/new_game_tab.cpp" line="291"/>
         <source>Remove Image</source>
         <translation>Forigi bildon</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="113"/>
+        <location filename="../src/new_game_tab.cpp" line="114"/>
         <source>Image Properties</source>
         <translation>Ecoj de bildo</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="132"/>
-        <location filename="../src/new_game_tab.cpp" line="383"/>
+        <location filename="../src/new_game_tab.cpp" line="133"/>
+        <location filename="../src/new_game_tab.cpp" line="384"/>
         <source>%L1 pieces</source>
         <translation>%L1 eroj</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="193"/>
+        <location filename="../src/new_game_tab.cpp" line="194"/>
         <source>Copying images...</source>
         <translation>Kopiado de bildo...</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="193"/>
+        <location filename="../src/new_game_tab.cpp" line="194"/>
         <source>Cancel</source>
         <translation>Nuligi</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="286"/>
+        <location filename="../src/new_game_tab.cpp" line="287"/>
         <source>Remove selected image?</source>
         <translation>Ĉu forigi elektitan bildon?</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="288"/>
+        <location filename="../src/new_game_tab.cpp" line="289"/>
         <source>Remove selected image?
 
 There are saved games using this image that will also be removed.</source>
@@ -244,7 +249,7 @@ There are saved games using this image that will also be removed.</source>
 Estas konservataj ludoj, uzantaj ĉi tiun bildon, kiuj estas ankaŭ forigotaj.</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="493"/>
+        <location filename="../src/new_game_tab.cpp" line="494"/>
         <source>Untitled</source>
         <translation>Sentitola</translation>
     </message>
@@ -280,7 +285,7 @@ Estas konservataj ludoj, uzantaj ĉi tiun bildon, kiuj estas ankaŭ forigotaj.</
 <context>
     <name>Overview</name>
     <message>
-        <location filename="../src/overview.cpp" line="38"/>
+        <location filename="../src/overview.cpp" line="39"/>
         <source>Overview</source>
         <translation>Superrigardo</translation>
     </message>
@@ -336,215 +341,215 @@ Estas konservataj ludoj, uzantaj ĉi tiun bildon, kiuj estas ankaŭ forigotaj.</
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/main.cpp" line="168"/>
-        <location filename="../src/window.cpp" line="50"/>
-        <location filename="../src/window.cpp" line="286"/>
+        <location filename="../src/main.cpp" line="56"/>
+        <location filename="../src/main.cpp" line="163"/>
+        <location filename="../src/window.cpp" line="283"/>
         <source>Tetzle</source>
         <translation>Tetzlo</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="80"/>
+        <location filename="../src/window.cpp" line="79"/>
         <source>&amp;Game</source>
         <translation>&amp;Ludo</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="84"/>
+        <location filename="../src/window.cpp" line="83"/>
         <source>&amp;Retrieve Pieces</source>
         <translation>&amp;Ricevi erojn</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="84"/>
+        <location filename="../src/window.cpp" line="83"/>
         <source>Ctrl+R</source>
         <translation>Stir+R</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="88"/>
+        <location filename="../src/window.cpp" line="87"/>
         <source>&amp;Quit</source>
         <translation>&amp;Eliri</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="81"/>
+        <location filename="../src/window.cpp" line="80"/>
         <source>&amp;Choose...</source>
         <translation>&amp;Elektu...</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="91"/>
+        <location filename="../src/window.cpp" line="90"/>
         <source>&amp;View</source>
         <translation>&amp;Vido</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="92"/>
+        <location filename="../src/window.cpp" line="91"/>
         <source>Zoom &amp;In</source>
         <translation>Pl&amp;igrandigi</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="92"/>
+        <location filename="../src/window.cpp" line="91"/>
         <source>+</source>
         <translation>+</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="95"/>
+        <location filename="../src/window.cpp" line="94"/>
         <source>Zoom &amp;Out</source>
         <translation>&amp;Malpligrandigi</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="95"/>
+        <location filename="../src/window.cpp" line="94"/>
         <source>-</source>
         <translation>-</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="98"/>
+        <location filename="../src/window.cpp" line="97"/>
         <source>Best &amp;Fit</source>
         <translation>&amp;Plejbona adapto</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="101"/>
+        <location filename="../src/window.cpp" line="100"/>
         <source>Show O&amp;verview</source>
         <translation>&amp;Montri superrigardon</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="101"/>
+        <location filename="../src/window.cpp" line="100"/>
         <source>Tab</source>
         <translation>Langeto</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="107"/>
+        <location filename="../src/window.cpp" line="106"/>
         <source>F&amp;ullscreen</source>
         <translation>T&amp;utekrane</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="111"/>
+        <location filename="../src/window.cpp" line="110"/>
         <source>F11</source>
         <translation>F11</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="113"/>
+        <location filename="../src/window.cpp" line="112"/>
         <source>Ctrl+F</source>
         <translation>Stir+F</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="116"/>
+        <location filename="../src/window.cpp" line="115"/>
         <source>&amp;Settings</source>
         <translation>&amp;Agordoj</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="117"/>
+        <location filename="../src/window.cpp" line="116"/>
         <source>&amp;Appearance...</source>
         <translation>&amp;Apero...</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="118"/>
+        <location filename="../src/window.cpp" line="117"/>
         <source>&amp;Language...</source>
         <translation>&amp;Lingvo...</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="120"/>
+        <location filename="../src/window.cpp" line="119"/>
         <source>&amp;Help</source>
         <translation>&amp;Helpo</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="121"/>
+        <location filename="../src/window.cpp" line="120"/>
         <source>&amp;Controls</source>
         <translation>&amp;Stiriloj</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="123"/>
+        <location filename="../src/window.cpp" line="122"/>
         <source>&amp;About</source>
         <translation>&amp;Pri</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="125"/>
+        <location filename="../src/window.cpp" line="124"/>
         <source>About &amp;Qt</source>
         <translation>Pri &amp;Qt</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="252"/>
+        <location filename="../src/window.cpp" line="249"/>
         <source>Controls</source>
         <translation>Stiriloj</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="259"/>
+        <location filename="../src/window.cpp" line="256"/>
         <source>&lt;b&gt;Pick Up Pieces:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Prenu erojn;&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="260"/>
-        <location filename="../src/window.cpp" line="262"/>
+        <location filename="../src/window.cpp" line="257"/>
+        <location filename="../src/window.cpp" line="259"/>
         <source>Left Click or Space</source>
         <translation>Maldekstra alklako aŭ spaceto</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="261"/>
+        <location filename="../src/window.cpp" line="258"/>
         <source>&lt;b&gt;Drop Pieces:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Demetu erojn:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="263"/>
+        <location filename="../src/window.cpp" line="260"/>
         <source>&lt;b&gt;Select Pieces:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Elektu erojn:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="264"/>
+        <location filename="../src/window.cpp" line="261"/>
         <source>Left Drag</source>
         <translation>Maldekstra ŝovo</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="265"/>
+        <location filename="../src/window.cpp" line="262"/>
         <source>&lt;b&gt;Rotate Pieces:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Turnu erojn:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="266"/>
+        <location filename="../src/window.cpp" line="263"/>
         <source>Right Click, Control + Left Click, or R</source>
         <translation>Dekstra alklako, stirklavo + maldekstra alklako aŭ R</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="267"/>
+        <location filename="../src/window.cpp" line="264"/>
         <source>&lt;b&gt;Drag Puzzle:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Ŝovu puzlon:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="268"/>
+        <location filename="../src/window.cpp" line="265"/>
         <source>Middle Click, Shift + Left Click, or Arrows</source>
         <translation>Meza alklako, majuskliga klavo + dekstra alklako aŭ sagoj</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="269"/>
+        <location filename="../src/window.cpp" line="266"/>
         <source>&lt;b&gt;Zoom Puzzle:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Pligrandigu puzlon:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="270"/>
+        <location filename="../src/window.cpp" line="267"/>
         <source>Scrollwheel or +/-</source>
         <translation>Rulumrado aŭ +/-</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="271"/>
+        <location filename="../src/window.cpp" line="268"/>
         <source>&lt;b&gt;Move Cursor:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Movu kursoron:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="272"/>
+        <location filename="../src/window.cpp" line="269"/>
         <source>Move mouse or W,A,D,S</source>
         <translation>Movi muson aŭ W, A, D kaj S</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="285"/>
+        <location filename="../src/window.cpp" line="282"/>
         <source>About Tetzle</source>
         <translation>Pri Tetzlo</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="287"/>
+        <location filename="../src/window.cpp" line="284"/>
         <source>A jigsaw puzzle with tetrominoes for pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="288"/>
+        <location filename="../src/window.cpp" line="285"/>
         <source>Copyright &amp;copy; 2008-%1 Graeme Gott</source>
         <translation>Kopirajto &amp;copy; 2008-%1 Graeme GOTT</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="289"/>
+        <location filename="../src/window.cpp" line="286"/>
         <source>Released under the &lt;a href=%1&gt;GPL 3&lt;/a&gt; license</source>
         <translation>Publikigita sub la permesilo &lt;a href=%1&gt;GPL 3&lt;/a&gt;</translation>
     </message>
@@ -552,12 +557,12 @@ Estas konservataj ludoj, uzantaj ĉi tiun bildon, kiuj estas ankaŭ forigotaj.</
 <context>
     <name>ZoomSlider</name>
     <message>
-        <location filename="../src/zoom_slider.cpp" line="38"/>
+        <location filename="../src/zoom_slider.cpp" line="40"/>
         <source>??%</source>
         <translation>??%</translation>
     </message>
     <message>
-        <location filename="../src/zoom_slider.cpp" line="63"/>
+        <location filename="../src/zoom_slider.cpp" line="65"/>
         <source>%1%</source>
         <translation>%1%</translation>
     </message>

--- a/translations/tetzle_es.ts
+++ b/translations/tetzle_es.ts
@@ -4,7 +4,7 @@
 <context>
     <name>AddImage</name>
     <message>
-        <location filename="../src/add_image.cpp" line="87"/>
+        <location filename="../src/add_image.cpp" line="79"/>
         <source>Open Image</source>
         <translation>Abrir imagen</translation>
     </message>
@@ -32,22 +32,27 @@
         <translation>Colocar sombras</translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="77"/>
+        <location filename="../src/appearance_dialog.cpp" line="76"/>
+        <source>Success message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/appearance_dialog.cpp" line="79"/>
         <source>Colors</source>
         <translation>Colores</translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="96"/>
+        <location filename="../src/appearance_dialog.cpp" line="98"/>
         <source>Background:</source>
         <translation>Fondo:</translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="97"/>
+        <location filename="../src/appearance_dialog.cpp" line="99"/>
         <source>Shadow:</source>
         <translation>Sombra:</translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="98"/>
+        <location filename="../src/appearance_dialog.cpp" line="100"/>
         <source>Highlight:</source>
         <translation>Destacar:</translation>
     </message>
@@ -55,59 +60,59 @@
 <context>
     <name>Board</name>
     <message>
-        <location filename="../src/board.cpp" line="187"/>
-        <location filename="../src/board.cpp" line="293"/>
-        <location filename="../src/board.cpp" line="361"/>
+        <location filename="../src/board.cpp" line="190"/>
+        <location filename="../src/board.cpp" line="301"/>
+        <location filename="../src/board.cpp" line="369"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="187"/>
-        <location filename="../src/board.cpp" line="293"/>
+        <location filename="../src/board.cpp" line="190"/>
+        <location filename="../src/board.cpp" line="301"/>
         <source>Missing image.</source>
         <translation>Falta imagen.</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="194"/>
-        <location filename="../src/board.cpp" line="269"/>
-        <location filename="../src/main.cpp" line="167"/>
+        <location filename="../src/board.cpp" line="197"/>
+        <location filename="../src/board.cpp" line="277"/>
+        <location filename="../src/main.cpp" line="162"/>
         <source>Please Wait</source>
         <translation>Por favor, Espera</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="216"/>
-        <location filename="../src/board.cpp" line="368"/>
+        <location filename="../src/board.cpp" line="219"/>
+        <location filename="../src/board.cpp" line="376"/>
         <source>Loading image...</source>
         <translation>Cargando imagen ...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="222"/>
+        <location filename="../src/board.cpp" line="225"/>
         <source>Generating puzzle...</source>
         <translation>Generando puzzle...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="228"/>
-        <location filename="../src/board.cpp" line="242"/>
+        <location filename="../src/board.cpp" line="236"/>
+        <location filename="../src/board.cpp" line="250"/>
         <source>Creating pieces...</source>
         <translation>Creando piezas ...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="281"/>
+        <location filename="../src/board.cpp" line="289"/>
         <source>Loading puzzle...</source>
         <translation>Cargando puzzle ...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="306"/>
+        <location filename="../src/board.cpp" line="314"/>
         <source>Unknown data format</source>
         <translation>Formato de datos desconocido</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="356"/>
+        <location filename="../src/board.cpp" line="364"/>
         <source>Unknown element &apos;%1&apos;</source>
         <translation>Elemento desconocido &apos;% 1&apos;</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="361"/>
+        <location filename="../src/board.cpp" line="369"/>
         <source>Error parsing XML file.
 
 %1</source>
@@ -116,22 +121,22 @@
 % 1</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="372"/>
+        <location filename="../src/board.cpp" line="380"/>
         <source>Loading pieces...</source>
         <translation>Cargando piezas</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="454"/>
+        <location filename="../src/board.cpp" line="462"/>
         <source>Retrieving pieces...</source>
         <translation>Recuperando piezas ...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="994"/>
+        <location filename="../src/board.cpp" line="1002"/>
         <source>Placing pieces...</source>
         <translation>Colocación de las piezas...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="1326"/>
+        <location filename="../src/board.cpp" line="1331"/>
         <source>Success</source>
         <translation>Acierto</translation>
     </message>
@@ -175,22 +180,22 @@
 <context>
     <name>LocaleDialog</name>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="50"/>
+        <location filename="../src/locale_dialog.cpp" line="52"/>
         <source>Select application language:</source>
         <translation>Seleccionar idioma del programa:</translation>
     </message>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="53"/>
+        <location filename="../src/locale_dialog.cpp" line="55"/>
         <source>&lt;System Language&gt;</source>
         <translation>&lt;Idioma del Sistema&gt;</translation>
     </message>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="183"/>
+        <location filename="../src/locale_dialog.cpp" line="172"/>
         <source>Note</source>
         <translation>Nota</translation>
     </message>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="183"/>
+        <location filename="../src/locale_dialog.cpp" line="172"/>
         <source>Please restart this application for the change in language to take effect.</source>
         <translation>Por favor, reinicia el programa para aplicar el cambio de idioma.</translation>
     </message>
@@ -198,44 +203,44 @@
 <context>
     <name>NewGameTab</name>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="105"/>
+        <location filename="../src/new_game_tab.cpp" line="106"/>
         <source>Add Image</source>
         <translation>Añadir imagen</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="109"/>
-        <location filename="../src/new_game_tab.cpp" line="290"/>
+        <location filename="../src/new_game_tab.cpp" line="110"/>
+        <location filename="../src/new_game_tab.cpp" line="291"/>
         <source>Remove Image</source>
         <translation>Eliminar imagen</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="113"/>
+        <location filename="../src/new_game_tab.cpp" line="114"/>
         <source>Image Properties</source>
         <translation>Propiedades de la imagen</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="132"/>
-        <location filename="../src/new_game_tab.cpp" line="383"/>
+        <location filename="../src/new_game_tab.cpp" line="133"/>
+        <location filename="../src/new_game_tab.cpp" line="384"/>
         <source>%L1 pieces</source>
         <translation>%L1 piezas</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="193"/>
+        <location filename="../src/new_game_tab.cpp" line="194"/>
         <source>Copying images...</source>
         <translation>Copia de imágenes ...</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="193"/>
+        <location filename="../src/new_game_tab.cpp" line="194"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="286"/>
+        <location filename="../src/new_game_tab.cpp" line="287"/>
         <source>Remove selected image?</source>
         <translation>Eliminar la imagen seleccionada?</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="288"/>
+        <location filename="../src/new_game_tab.cpp" line="289"/>
         <source>Remove selected image?
 
 There are saved games using this image that will also be removed.</source>
@@ -244,7 +249,7 @@ There are saved games using this image that will also be removed.</source>
 Hay juegos guardados que usan esta imagen que será eliminada.</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="493"/>
+        <location filename="../src/new_game_tab.cpp" line="494"/>
         <source>Untitled</source>
         <translation>Sin título</translation>
     </message>
@@ -280,7 +285,7 @@ Hay juegos guardados que usan esta imagen que será eliminada.</translation>
 <context>
     <name>Overview</name>
     <message>
-        <location filename="../src/overview.cpp" line="38"/>
+        <location filename="../src/overview.cpp" line="39"/>
         <source>Overview</source>
         <translation>Vista general</translation>
     </message>
@@ -336,215 +341,215 @@ Hay juegos guardados que usan esta imagen que será eliminada.</translation>
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/main.cpp" line="168"/>
-        <location filename="../src/window.cpp" line="50"/>
-        <location filename="../src/window.cpp" line="286"/>
+        <location filename="../src/main.cpp" line="56"/>
+        <location filename="../src/main.cpp" line="163"/>
+        <location filename="../src/window.cpp" line="283"/>
         <source>Tetzle</source>
         <translation>Tetzle</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="80"/>
+        <location filename="../src/window.cpp" line="79"/>
         <source>&amp;Game</source>
         <translation>&amp;Juego</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="84"/>
+        <location filename="../src/window.cpp" line="83"/>
         <source>&amp;Retrieve Pieces</source>
         <translation>&amp;Recuperar Piezas</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="84"/>
+        <location filename="../src/window.cpp" line="83"/>
         <source>Ctrl+R</source>
         <translation>Ctrl+R</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="88"/>
+        <location filename="../src/window.cpp" line="87"/>
         <source>&amp;Quit</source>
         <translation>&amp;Salir</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="81"/>
+        <location filename="../src/window.cpp" line="80"/>
         <source>&amp;Choose...</source>
         <translation>&amp;Elegir</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="91"/>
+        <location filename="../src/window.cpp" line="90"/>
         <source>&amp;View</source>
         <translation>&amp;Ver</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="92"/>
+        <location filename="../src/window.cpp" line="91"/>
         <source>Zoom &amp;In</source>
         <translation>Acercar&amp;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="92"/>
+        <location filename="../src/window.cpp" line="91"/>
         <source>+</source>
         <translation>+</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="95"/>
+        <location filename="../src/window.cpp" line="94"/>
         <source>Zoom &amp;Out</source>
         <translation>Alejar&amp;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="95"/>
+        <location filename="../src/window.cpp" line="94"/>
         <source>-</source>
         <translation>-</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="98"/>
+        <location filename="../src/window.cpp" line="97"/>
         <source>Best &amp;Fit</source>
         <translation>Mejor &amp;Ajuste</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="101"/>
+        <location filename="../src/window.cpp" line="100"/>
         <source>Show O&amp;verview</source>
         <translation>Mostrar R&amp;esumen</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="101"/>
+        <location filename="../src/window.cpp" line="100"/>
         <source>Tab</source>
         <translation>Tab</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="107"/>
+        <location filename="../src/window.cpp" line="106"/>
         <source>F&amp;ullscreen</source>
         <translation>P&amp;antalla Completa</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="111"/>
+        <location filename="../src/window.cpp" line="110"/>
         <source>F11</source>
         <translation>F11</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="113"/>
+        <location filename="../src/window.cpp" line="112"/>
         <source>Ctrl+F</source>
         <translation>Ctrl+F</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="116"/>
+        <location filename="../src/window.cpp" line="115"/>
         <source>&amp;Settings</source>
         <translation>&amp;Ajustes</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="117"/>
+        <location filename="../src/window.cpp" line="116"/>
         <source>&amp;Appearance...</source>
         <translation>&amp;Apariencia...</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="118"/>
+        <location filename="../src/window.cpp" line="117"/>
         <source>&amp;Language...</source>
         <translation>&amp;Idioma...</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="120"/>
+        <location filename="../src/window.cpp" line="119"/>
         <source>&amp;Help</source>
         <translation>&amp;Ayuda</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="121"/>
+        <location filename="../src/window.cpp" line="120"/>
         <source>&amp;Controls</source>
         <translation>&amp;Controles</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="123"/>
+        <location filename="../src/window.cpp" line="122"/>
         <source>&amp;About</source>
         <translation>&amp;Acerca de</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="125"/>
+        <location filename="../src/window.cpp" line="124"/>
         <source>About &amp;Qt</source>
         <translation>Acerca de &amp;Qt</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="252"/>
+        <location filename="../src/window.cpp" line="249"/>
         <source>Controls</source>
         <translation>Controles</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="259"/>
+        <location filename="../src/window.cpp" line="256"/>
         <source>&lt;b&gt;Pick Up Pieces:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Recoger Piezas:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="260"/>
-        <location filename="../src/window.cpp" line="262"/>
+        <location filename="../src/window.cpp" line="257"/>
+        <location filename="../src/window.cpp" line="259"/>
         <source>Left Click or Space</source>
         <translation>Clic Izquierdo o Espacio</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="261"/>
+        <location filename="../src/window.cpp" line="258"/>
         <source>&lt;b&gt;Drop Pieces:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Colocar las Piezas:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="263"/>
+        <location filename="../src/window.cpp" line="260"/>
         <source>&lt;b&gt;Select Pieces:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Seleccionar Piezas:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="264"/>
+        <location filename="../src/window.cpp" line="261"/>
         <source>Left Drag</source>
         <translation>Arrastrar a la izquierda</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="265"/>
+        <location filename="../src/window.cpp" line="262"/>
         <source>&lt;b&gt;Rotate Pieces:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Rotar Piezas:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="266"/>
+        <location filename="../src/window.cpp" line="263"/>
         <source>Right Click, Control + Left Click, or R</source>
         <translation>Click Derecho, Control + Clic Izquierdo o R</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="267"/>
+        <location filename="../src/window.cpp" line="264"/>
         <source>&lt;b&gt;Drag Puzzle:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Arrastrar Puzzle:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="268"/>
+        <location filename="../src/window.cpp" line="265"/>
         <source>Middle Click, Shift + Left Click, or Arrows</source>
         <translation>Click Rueda Raton , Mayús + Clic Izquierdo, o las Flechas</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="269"/>
+        <location filename="../src/window.cpp" line="266"/>
         <source>&lt;b&gt;Zoom Puzzle:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Zoom Puzzle:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="270"/>
+        <location filename="../src/window.cpp" line="267"/>
         <source>Scrollwheel or +/-</source>
         <translation>Rueda del Ratón o +/-</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="271"/>
+        <location filename="../src/window.cpp" line="268"/>
         <source>&lt;b&gt;Move Cursor:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Mover Cursor:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="272"/>
+        <location filename="../src/window.cpp" line="269"/>
         <source>Move mouse or W,A,D,S</source>
         <translation>Mover el ratón o W, A, D, S</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="285"/>
+        <location filename="../src/window.cpp" line="282"/>
         <source>About Tetzle</source>
         <translation>Acerca de Tetzle</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="287"/>
+        <location filename="../src/window.cpp" line="284"/>
         <source>A jigsaw puzzle with tetrominoes for pieces</source>
         <translation>Un puzzle con tetrominoes para piezas</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="288"/>
+        <location filename="../src/window.cpp" line="285"/>
         <source>Copyright &amp;copy; 2008-%1 Graeme Gott</source>
         <translation>Copyright &amp;copy; 2008-%1 Graeme Gott</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="289"/>
+        <location filename="../src/window.cpp" line="286"/>
         <source>Released under the &lt;a href=%1&gt;GPL 3&lt;/a&gt; license</source>
         <translation>Publicado bajo la licencia &lt;a href=%1&gt;GPL 3&lt;/a&gt;</translation>
     </message>
@@ -552,12 +557,12 @@ Hay juegos guardados que usan esta imagen que será eliminada.</translation>
 <context>
     <name>ZoomSlider</name>
     <message>
-        <location filename="../src/zoom_slider.cpp" line="38"/>
+        <location filename="../src/zoom_slider.cpp" line="40"/>
         <source>??%</source>
         <translation>??%</translation>
     </message>
     <message>
-        <location filename="../src/zoom_slider.cpp" line="63"/>
+        <location filename="../src/zoom_slider.cpp" line="65"/>
         <source>%1%</source>
         <translation>%1%</translation>
     </message>

--- a/translations/tetzle_fr.ts
+++ b/translations/tetzle_fr.ts
@@ -4,7 +4,7 @@
 <context>
     <name>AddImage</name>
     <message>
-        <location filename="../src/add_image.cpp" line="87"/>
+        <location filename="../src/add_image.cpp" line="79"/>
         <source>Open Image</source>
         <translation>Ouvrir une image</translation>
     </message>
@@ -32,22 +32,27 @@
         <translation>Dissiper les zones d&apos;ombre</translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="77"/>
+        <location filename="../src/appearance_dialog.cpp" line="76"/>
+        <source>Success message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/appearance_dialog.cpp" line="79"/>
         <source>Colors</source>
         <translation>Couleurs</translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="96"/>
+        <location filename="../src/appearance_dialog.cpp" line="98"/>
         <source>Background:</source>
         <translation>Arrière-plan :</translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="97"/>
+        <location filename="../src/appearance_dialog.cpp" line="99"/>
         <source>Shadow:</source>
         <translation>Ombre :</translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="98"/>
+        <location filename="../src/appearance_dialog.cpp" line="100"/>
         <source>Highlight:</source>
         <translation>Surbrillance :</translation>
     </message>
@@ -55,59 +60,59 @@
 <context>
     <name>Board</name>
     <message>
-        <location filename="../src/board.cpp" line="187"/>
-        <location filename="../src/board.cpp" line="293"/>
-        <location filename="../src/board.cpp" line="361"/>
+        <location filename="../src/board.cpp" line="190"/>
+        <location filename="../src/board.cpp" line="301"/>
+        <location filename="../src/board.cpp" line="369"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="187"/>
-        <location filename="../src/board.cpp" line="293"/>
+        <location filename="../src/board.cpp" line="190"/>
+        <location filename="../src/board.cpp" line="301"/>
         <source>Missing image.</source>
         <translation>Image manquante.</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="194"/>
-        <location filename="../src/board.cpp" line="269"/>
-        <location filename="../src/main.cpp" line="167"/>
+        <location filename="../src/board.cpp" line="197"/>
+        <location filename="../src/board.cpp" line="277"/>
+        <location filename="../src/main.cpp" line="162"/>
         <source>Please Wait</source>
         <translation>Veuillez patienter</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="216"/>
-        <location filename="../src/board.cpp" line="368"/>
+        <location filename="../src/board.cpp" line="219"/>
+        <location filename="../src/board.cpp" line="376"/>
         <source>Loading image...</source>
         <translation>Chargement de l&apos;image…</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="222"/>
+        <location filename="../src/board.cpp" line="225"/>
         <source>Generating puzzle...</source>
         <translation>Génération du puzzle…</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="228"/>
-        <location filename="../src/board.cpp" line="242"/>
+        <location filename="../src/board.cpp" line="236"/>
+        <location filename="../src/board.cpp" line="250"/>
         <source>Creating pieces...</source>
         <translation>Création des pièces…</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="281"/>
+        <location filename="../src/board.cpp" line="289"/>
         <source>Loading puzzle...</source>
         <translation>Chargement du puzzle…</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="306"/>
+        <location filename="../src/board.cpp" line="314"/>
         <source>Unknown data format</source>
         <translation>Format de donnée inconnu</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="356"/>
+        <location filename="../src/board.cpp" line="364"/>
         <source>Unknown element &apos;%1&apos;</source>
         <translation>Élément inconnu &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="361"/>
+        <location filename="../src/board.cpp" line="369"/>
         <source>Error parsing XML file.
 
 %1</source>
@@ -116,22 +121,22 @@
 %1</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="372"/>
+        <location filename="../src/board.cpp" line="380"/>
         <source>Loading pieces...</source>
         <translation>Chargement des pièces…</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="454"/>
+        <location filename="../src/board.cpp" line="462"/>
         <source>Retrieving pieces...</source>
         <translation>Pioche des pièces…</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="994"/>
+        <location filename="../src/board.cpp" line="1002"/>
         <source>Placing pieces...</source>
         <translation>Disposition des pièces…</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="1326"/>
+        <location filename="../src/board.cpp" line="1331"/>
         <source>Success</source>
         <translation>Succès</translation>
     </message>
@@ -175,22 +180,22 @@
 <context>
     <name>LocaleDialog</name>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="50"/>
+        <location filename="../src/locale_dialog.cpp" line="52"/>
         <source>Select application language:</source>
         <translation>Sélectionner la langue de l&apos;application :</translation>
     </message>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="53"/>
+        <location filename="../src/locale_dialog.cpp" line="55"/>
         <source>&lt;System Language&gt;</source>
         <translation>&lt;Langue du système&gt;</translation>
     </message>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="183"/>
+        <location filename="../src/locale_dialog.cpp" line="172"/>
         <source>Note</source>
         <translation>Remarque</translation>
     </message>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="183"/>
+        <location filename="../src/locale_dialog.cpp" line="172"/>
         <source>Please restart this application for the change in language to take effect.</source>
         <translation>Veuillez relancer l&apos;application pour que la modification prenne effet. </translation>
     </message>
@@ -198,44 +203,44 @@
 <context>
     <name>NewGameTab</name>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="105"/>
+        <location filename="../src/new_game_tab.cpp" line="106"/>
         <source>Add Image</source>
         <translation>Ajouter une image</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="109"/>
-        <location filename="../src/new_game_tab.cpp" line="290"/>
+        <location filename="../src/new_game_tab.cpp" line="110"/>
+        <location filename="../src/new_game_tab.cpp" line="291"/>
         <source>Remove Image</source>
         <translation>Supprimer l&apos;image</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="113"/>
+        <location filename="../src/new_game_tab.cpp" line="114"/>
         <source>Image Properties</source>
         <translation>Propriétés de l&apos;image</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="132"/>
-        <location filename="../src/new_game_tab.cpp" line="383"/>
+        <location filename="../src/new_game_tab.cpp" line="133"/>
+        <location filename="../src/new_game_tab.cpp" line="384"/>
         <source>%L1 pieces</source>
         <translation>%L1 pièces</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="193"/>
+        <location filename="../src/new_game_tab.cpp" line="194"/>
         <source>Copying images...</source>
         <translation>Copie des images…</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="193"/>
+        <location filename="../src/new_game_tab.cpp" line="194"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="286"/>
+        <location filename="../src/new_game_tab.cpp" line="287"/>
         <source>Remove selected image?</source>
         <translation>Supprimer l&apos;image sélectionnée ?</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="288"/>
+        <location filename="../src/new_game_tab.cpp" line="289"/>
         <source>Remove selected image?
 
 There are saved games using this image that will also be removed.</source>
@@ -244,7 +249,7 @@ There are saved games using this image that will also be removed.</source>
 Les parties utilisant cette image seront également supprimées.</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="493"/>
+        <location filename="../src/new_game_tab.cpp" line="494"/>
         <source>Untitled</source>
         <translation>Sans titre</translation>
     </message>
@@ -280,7 +285,7 @@ Les parties utilisant cette image seront également supprimées.</translation>
 <context>
     <name>Overview</name>
     <message>
-        <location filename="../src/overview.cpp" line="38"/>
+        <location filename="../src/overview.cpp" line="39"/>
         <source>Overview</source>
         <translation>Vue d&apos;ensemble</translation>
     </message>
@@ -336,215 +341,215 @@ Les parties utilisant cette image seront également supprimées.</translation>
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/main.cpp" line="168"/>
-        <location filename="../src/window.cpp" line="50"/>
-        <location filename="../src/window.cpp" line="286"/>
+        <location filename="../src/main.cpp" line="56"/>
+        <location filename="../src/main.cpp" line="163"/>
+        <location filename="../src/window.cpp" line="283"/>
         <source>Tetzle</source>
         <translation>Tetzle</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="80"/>
+        <location filename="../src/window.cpp" line="79"/>
         <source>&amp;Game</source>
         <translation>&amp;Jeu</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="84"/>
+        <location filename="../src/window.cpp" line="83"/>
         <source>&amp;Retrieve Pieces</source>
         <translation>&amp;Piocher des pièces</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="84"/>
+        <location filename="../src/window.cpp" line="83"/>
         <source>Ctrl+R</source>
         <translation>Ctrl+R</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="88"/>
+        <location filename="../src/window.cpp" line="87"/>
         <source>&amp;Quit</source>
         <translation>&amp;Quitter</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="81"/>
+        <location filename="../src/window.cpp" line="80"/>
         <source>&amp;Choose...</source>
         <translation>&amp;Choisir…</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="91"/>
+        <location filename="../src/window.cpp" line="90"/>
         <source>&amp;View</source>
         <translation>&amp;Afficher</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="92"/>
+        <location filename="../src/window.cpp" line="91"/>
         <source>Zoom &amp;In</source>
         <translation>Zoom &amp;avant</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="92"/>
+        <location filename="../src/window.cpp" line="91"/>
         <source>+</source>
         <translation>+</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="95"/>
+        <location filename="../src/window.cpp" line="94"/>
         <source>Zoom &amp;Out</source>
         <translation>Zoom &amp;arrière</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="95"/>
+        <location filename="../src/window.cpp" line="94"/>
         <source>-</source>
         <translation>-</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="98"/>
+        <location filename="../src/window.cpp" line="97"/>
         <source>Best &amp;Fit</source>
         <translation>&amp;Mise au point optimale</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="101"/>
+        <location filename="../src/window.cpp" line="100"/>
         <source>Show O&amp;verview</source>
         <translation>Afficher la &amp;vue d&apos;ensemble</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="101"/>
+        <location filename="../src/window.cpp" line="100"/>
         <source>Tab</source>
         <translation>Tab</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="107"/>
+        <location filename="../src/window.cpp" line="106"/>
         <source>F&amp;ullscreen</source>
         <translation>&amp;Plein écran</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="111"/>
+        <location filename="../src/window.cpp" line="110"/>
         <source>F11</source>
         <translation>F11</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="113"/>
+        <location filename="../src/window.cpp" line="112"/>
         <source>Ctrl+F</source>
         <translation>Ctrl+F</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="116"/>
+        <location filename="../src/window.cpp" line="115"/>
         <source>&amp;Settings</source>
         <translation>&amp;Paramètres</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="117"/>
+        <location filename="../src/window.cpp" line="116"/>
         <source>&amp;Appearance...</source>
         <translation>&amp;Apparence…</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="118"/>
+        <location filename="../src/window.cpp" line="117"/>
         <source>&amp;Language...</source>
         <translation>&amp;Langue…</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="120"/>
+        <location filename="../src/window.cpp" line="119"/>
         <source>&amp;Help</source>
         <translation>&amp;Aide</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="121"/>
+        <location filename="../src/window.cpp" line="120"/>
         <source>&amp;Controls</source>
         <translation>&amp;Commandes</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="123"/>
+        <location filename="../src/window.cpp" line="122"/>
         <source>&amp;About</source>
         <translation>À &amp;propos de…</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="125"/>
+        <location filename="../src/window.cpp" line="124"/>
         <source>About &amp;Qt</source>
         <translation>À propos de &amp;Qt</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="252"/>
+        <location filename="../src/window.cpp" line="249"/>
         <source>Controls</source>
         <translation>Contrôles</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="259"/>
+        <location filename="../src/window.cpp" line="256"/>
         <source>&lt;b&gt;Pick Up Pieces:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Ramasser des pièces :&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="260"/>
-        <location filename="../src/window.cpp" line="262"/>
+        <location filename="../src/window.cpp" line="257"/>
+        <location filename="../src/window.cpp" line="259"/>
         <source>Left Click or Space</source>
         <translation>Clic gauche ou Barre d&apos;espace</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="261"/>
+        <location filename="../src/window.cpp" line="258"/>
         <source>&lt;b&gt;Drop Pieces:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Relâcher des pièces :&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="263"/>
+        <location filename="../src/window.cpp" line="260"/>
         <source>&lt;b&gt;Select Pieces:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Sélectionner des pièces :&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="264"/>
+        <location filename="../src/window.cpp" line="261"/>
         <source>Left Drag</source>
         <translation>Faire glisser à gauche</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="265"/>
+        <location filename="../src/window.cpp" line="262"/>
         <source>&lt;b&gt;Rotate Pieces:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Rotation des pièces :&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="266"/>
+        <location filename="../src/window.cpp" line="263"/>
         <source>Right Click, Control + Left Click, or R</source>
         <translation>Clic droit, Contrôle + Clic gauche, ou R</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="267"/>
+        <location filename="../src/window.cpp" line="264"/>
         <source>&lt;b&gt;Drag Puzzle:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Faire glisser le puzzle :&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="268"/>
+        <location filename="../src/window.cpp" line="265"/>
         <source>Middle Click, Shift + Left Click, or Arrows</source>
         <translation>Clic du milieu, Maj + Clic gauche, ou flèches</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="269"/>
+        <location filename="../src/window.cpp" line="266"/>
         <source>&lt;b&gt;Zoom Puzzle:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Zoomer sur le puzzle :&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="270"/>
+        <location filename="../src/window.cpp" line="267"/>
         <source>Scrollwheel or +/-</source>
         <translation>Molette ou + / -</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="271"/>
+        <location filename="../src/window.cpp" line="268"/>
         <source>&lt;b&gt;Move Cursor:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Curseur de la souris :&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="272"/>
+        <location filename="../src/window.cpp" line="269"/>
         <source>Move mouse or W,A,D,S</source>
         <translation>Déplacez la souris ou utilisez W,A,D,S</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="285"/>
+        <location filename="../src/window.cpp" line="282"/>
         <source>About Tetzle</source>
         <translation>À propos de Tetzle</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="287"/>
+        <location filename="../src/window.cpp" line="284"/>
         <source>A jigsaw puzzle with tetrominoes for pieces</source>
         <translation>Un puzzle Jigsaw à base de tétraminos</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="288"/>
+        <location filename="../src/window.cpp" line="285"/>
         <source>Copyright &amp;copy; 2008-%1 Graeme Gott</source>
         <translation>Copyright &amp;copy; 2008-%1 Graeme Gott</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="289"/>
+        <location filename="../src/window.cpp" line="286"/>
         <source>Released under the &lt;a href=%1&gt;GPL 3&lt;/a&gt; license</source>
         <translation>Distribué sous licence GNU &lt;a href=%1&gt;GPL 3&lt;/a&gt;</translation>
     </message>
@@ -552,12 +557,12 @@ Les parties utilisant cette image seront également supprimées.</translation>
 <context>
     <name>ZoomSlider</name>
     <message>
-        <location filename="../src/zoom_slider.cpp" line="38"/>
+        <location filename="../src/zoom_slider.cpp" line="40"/>
         <source>??%</source>
         <translation>??%</translation>
     </message>
     <message>
-        <location filename="../src/zoom_slider.cpp" line="63"/>
+        <location filename="../src/zoom_slider.cpp" line="65"/>
         <source>%1%</source>
         <translation>%1%</translation>
     </message>

--- a/translations/tetzle_he.ts
+++ b/translations/tetzle_he.ts
@@ -4,7 +4,7 @@
 <context>
     <name>AddImage</name>
     <message>
-        <location filename="../src/add_image.cpp" line="87"/>
+        <location filename="../src/add_image.cpp" line="79"/>
         <source>Open Image</source>
         <translation>פתיחת תמונה</translation>
     </message>
@@ -32,22 +32,27 @@
         <translation>הטלת צללים</translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="77"/>
+        <location filename="../src/appearance_dialog.cpp" line="76"/>
+        <source>Success message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/appearance_dialog.cpp" line="79"/>
         <source>Colors</source>
         <translation>צבעים</translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="96"/>
+        <location filename="../src/appearance_dialog.cpp" line="98"/>
         <source>Background:</source>
         <translation>רקע אחורי:</translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="97"/>
+        <location filename="../src/appearance_dialog.cpp" line="99"/>
         <source>Shadow:</source>
         <translation>צל:</translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="98"/>
+        <location filename="../src/appearance_dialog.cpp" line="100"/>
         <source>Highlight:</source>
         <translation>הדגשה:</translation>
     </message>
@@ -55,59 +60,59 @@
 <context>
     <name>Board</name>
     <message>
-        <location filename="../src/board.cpp" line="187"/>
-        <location filename="../src/board.cpp" line="293"/>
-        <location filename="../src/board.cpp" line="361"/>
+        <location filename="../src/board.cpp" line="190"/>
+        <location filename="../src/board.cpp" line="301"/>
+        <location filename="../src/board.cpp" line="369"/>
         <source>Error</source>
         <translation>שגיאה</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="187"/>
-        <location filename="../src/board.cpp" line="293"/>
+        <location filename="../src/board.cpp" line="190"/>
+        <location filename="../src/board.cpp" line="301"/>
         <source>Missing image.</source>
         <translation>תמונה חסרה.</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="194"/>
-        <location filename="../src/board.cpp" line="269"/>
-        <location filename="../src/main.cpp" line="167"/>
+        <location filename="../src/board.cpp" line="197"/>
+        <location filename="../src/board.cpp" line="277"/>
+        <location filename="../src/main.cpp" line="162"/>
         <source>Please Wait</source>
         <translation>נא להמתין</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="216"/>
-        <location filename="../src/board.cpp" line="368"/>
+        <location filename="../src/board.cpp" line="219"/>
+        <location filename="../src/board.cpp" line="376"/>
         <source>Loading image...</source>
         <translation>טוען תמונה כעת...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="222"/>
+        <location filename="../src/board.cpp" line="225"/>
         <source>Generating puzzle...</source>
         <translation>מחולל פאזל כעת...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="228"/>
-        <location filename="../src/board.cpp" line="242"/>
+        <location filename="../src/board.cpp" line="236"/>
+        <location filename="../src/board.cpp" line="250"/>
         <source>Creating pieces...</source>
         <translation>יוצר חתיכות כעת...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="281"/>
+        <location filename="../src/board.cpp" line="289"/>
         <source>Loading puzzle...</source>
         <translation>טוען פאזל כעת...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="306"/>
+        <location filename="../src/board.cpp" line="314"/>
         <source>Unknown data format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="356"/>
+        <location filename="../src/board.cpp" line="364"/>
         <source>Unknown element &apos;%1&apos;</source>
         <translation>אלמנט לא ידוע &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="361"/>
+        <location filename="../src/board.cpp" line="369"/>
         <source>Error parsing XML file.
 
 %1</source>
@@ -116,22 +121,22 @@
 %1</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="372"/>
+        <location filename="../src/board.cpp" line="380"/>
         <source>Loading pieces...</source>
         <translation>טוען חתיכות כעת...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="454"/>
+        <location filename="../src/board.cpp" line="462"/>
         <source>Retrieving pieces...</source>
         <translation>מאחזר חתיכות כעת...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="994"/>
+        <location filename="../src/board.cpp" line="1002"/>
         <source>Placing pieces...</source>
         <translation>ממקם חתיכות כעת...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="1326"/>
+        <location filename="../src/board.cpp" line="1331"/>
         <source>Success</source>
         <translation>הצלחה</translation>
     </message>
@@ -175,22 +180,22 @@
 <context>
     <name>LocaleDialog</name>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="50"/>
+        <location filename="../src/locale_dialog.cpp" line="52"/>
         <source>Select application language:</source>
         <translation>בחירת שפת יישום:</translation>
     </message>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="53"/>
+        <location filename="../src/locale_dialog.cpp" line="55"/>
         <source>&lt;System Language&gt;</source>
         <translation>&lt;שפת מערכת&gt;</translation>
     </message>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="183"/>
+        <location filename="../src/locale_dialog.cpp" line="172"/>
         <source>Note</source>
         <translation>הערה</translation>
     </message>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="183"/>
+        <location filename="../src/locale_dialog.cpp" line="172"/>
         <source>Please restart this application for the change in language to take effect.</source>
         <translation>נא לאתחל את יישום זה כדי להחיל את השינוי בשפה.</translation>
     </message>
@@ -198,51 +203,51 @@
 <context>
     <name>NewGameTab</name>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="105"/>
+        <location filename="../src/new_game_tab.cpp" line="106"/>
         <source>Add Image</source>
         <translation>הוספת תמונה</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="109"/>
-        <location filename="../src/new_game_tab.cpp" line="290"/>
+        <location filename="../src/new_game_tab.cpp" line="110"/>
+        <location filename="../src/new_game_tab.cpp" line="291"/>
         <source>Remove Image</source>
         <translation>הסרת תמונה</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="113"/>
+        <location filename="../src/new_game_tab.cpp" line="114"/>
         <source>Image Properties</source>
         <translation>מאפייני תמונה</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="132"/>
-        <location filename="../src/new_game_tab.cpp" line="383"/>
+        <location filename="../src/new_game_tab.cpp" line="133"/>
+        <location filename="../src/new_game_tab.cpp" line="384"/>
         <source>%L1 pieces</source>
         <translation>%L1 חתיכות</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="193"/>
+        <location filename="../src/new_game_tab.cpp" line="194"/>
         <source>Copying images...</source>
         <translation>מעתיק תמונה כעת...</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="193"/>
+        <location filename="../src/new_game_tab.cpp" line="194"/>
         <source>Cancel</source>
         <translation>ביטול</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="286"/>
+        <location filename="../src/new_game_tab.cpp" line="287"/>
         <source>Remove selected image?</source>
         <translation>הסרת תמונה נבחרת?</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="288"/>
+        <location filename="../src/new_game_tab.cpp" line="289"/>
         <source>Remove selected image?
 
 There are saved games using this image that will also be removed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="493"/>
+        <location filename="../src/new_game_tab.cpp" line="494"/>
         <source>Untitled</source>
         <translation>ללא כותרת</translation>
     </message>
@@ -278,7 +283,7 @@ There are saved games using this image that will also be removed.</source>
 <context>
     <name>Overview</name>
     <message>
-        <location filename="../src/overview.cpp" line="38"/>
+        <location filename="../src/overview.cpp" line="39"/>
         <source>Overview</source>
         <translation>סקירה כללית</translation>
     </message>
@@ -334,215 +339,215 @@ There are saved games using this image that will also be removed.</source>
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/main.cpp" line="168"/>
-        <location filename="../src/window.cpp" line="50"/>
-        <location filename="../src/window.cpp" line="286"/>
+        <location filename="../src/main.cpp" line="56"/>
+        <location filename="../src/main.cpp" line="163"/>
+        <location filename="../src/window.cpp" line="283"/>
         <source>Tetzle</source>
         <translation>Tetzle</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="80"/>
+        <location filename="../src/window.cpp" line="79"/>
         <source>&amp;Game</source>
         <translation>&amp;משחק</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="84"/>
+        <location filename="../src/window.cpp" line="83"/>
         <source>&amp;Retrieve Pieces</source>
         <translation>&amp;אחזור חתיכות</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="84"/>
+        <location filename="../src/window.cpp" line="83"/>
         <source>Ctrl+R</source>
         <translation>Ctrl+R</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="88"/>
+        <location filename="../src/window.cpp" line="87"/>
         <source>&amp;Quit</source>
         <translation>י&amp;ציאה</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="81"/>
+        <location filename="../src/window.cpp" line="80"/>
         <source>&amp;Choose...</source>
         <translation>&amp;בחירה...</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="91"/>
+        <location filename="../src/window.cpp" line="90"/>
         <source>&amp;View</source>
         <translation>&amp;תצוגה</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="92"/>
+        <location filename="../src/window.cpp" line="91"/>
         <source>Zoom &amp;In</source>
         <translation>זום &amp;פנימה</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="92"/>
+        <location filename="../src/window.cpp" line="91"/>
         <source>+</source>
         <translation>+</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="95"/>
+        <location filename="../src/window.cpp" line="94"/>
         <source>Zoom &amp;Out</source>
         <translation>זום &amp;חוצה</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="95"/>
+        <location filename="../src/window.cpp" line="94"/>
         <source>-</source>
         <translation>-</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="98"/>
+        <location filename="../src/window.cpp" line="97"/>
         <source>Best &amp;Fit</source>
         <translation>התאמה &amp;מיטבית</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="101"/>
+        <location filename="../src/window.cpp" line="100"/>
         <source>Show O&amp;verview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="101"/>
+        <location filename="../src/window.cpp" line="100"/>
         <source>Tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="107"/>
+        <location filename="../src/window.cpp" line="106"/>
         <source>F&amp;ullscreen</source>
         <translation>&amp;מסך מלא</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="111"/>
+        <location filename="../src/window.cpp" line="110"/>
         <source>F11</source>
         <translation>F11</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="113"/>
+        <location filename="../src/window.cpp" line="112"/>
         <source>Ctrl+F</source>
         <translation>Ctrl+F</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="116"/>
+        <location filename="../src/window.cpp" line="115"/>
         <source>&amp;Settings</source>
         <translation>&amp;הגדרות</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="117"/>
+        <location filename="../src/window.cpp" line="116"/>
         <source>&amp;Appearance...</source>
         <translation>&amp;מראה...</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="118"/>
+        <location filename="../src/window.cpp" line="117"/>
         <source>&amp;Language...</source>
         <translation>&amp;שפה...</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="120"/>
+        <location filename="../src/window.cpp" line="119"/>
         <source>&amp;Help</source>
         <translation>&amp;עזרה</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="121"/>
+        <location filename="../src/window.cpp" line="120"/>
         <source>&amp;Controls</source>
         <translation>&amp;בקרים</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="123"/>
+        <location filename="../src/window.cpp" line="122"/>
         <source>&amp;About</source>
         <translation>&amp;אודות</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="125"/>
+        <location filename="../src/window.cpp" line="124"/>
         <source>About &amp;Qt</source>
         <translation>אודות &amp;QT</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="252"/>
+        <location filename="../src/window.cpp" line="249"/>
         <source>Controls</source>
         <translation>בקרים</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="259"/>
+        <location filename="../src/window.cpp" line="256"/>
         <source>&lt;b&gt;Pick Up Pieces:&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="260"/>
-        <location filename="../src/window.cpp" line="262"/>
+        <location filename="../src/window.cpp" line="257"/>
+        <location filename="../src/window.cpp" line="259"/>
         <source>Left Click or Space</source>
         <translation>קליק שמאלי או רווח</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="261"/>
+        <location filename="../src/window.cpp" line="258"/>
         <source>&lt;b&gt;Drop Pieces:&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="263"/>
+        <location filename="../src/window.cpp" line="260"/>
         <source>&lt;b&gt;Select Pieces:&lt;/b&gt;</source>
         <translation>&lt;b&gt;בחירת חתיכות:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="264"/>
+        <location filename="../src/window.cpp" line="261"/>
         <source>Left Drag</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="265"/>
+        <location filename="../src/window.cpp" line="262"/>
         <source>&lt;b&gt;Rotate Pieces:&lt;/b&gt;</source>
         <translation>&lt;b&gt;סיבוב חתיכות:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="266"/>
+        <location filename="../src/window.cpp" line="263"/>
         <source>Right Click, Control + Left Click, or R</source>
         <translation>קליק ימני, Control + קליק שמאלי, או R</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="267"/>
+        <location filename="../src/window.cpp" line="264"/>
         <source>&lt;b&gt;Drag Puzzle:&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="268"/>
+        <location filename="../src/window.cpp" line="265"/>
         <source>Middle Click, Shift + Left Click, or Arrows</source>
         <translation>קליק אמצעי, Shift + קליק שמאלי, או חצים</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="269"/>
+        <location filename="../src/window.cpp" line="266"/>
         <source>&lt;b&gt;Zoom Puzzle:&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="270"/>
+        <location filename="../src/window.cpp" line="267"/>
         <source>Scrollwheel or +/-</source>
         <translation>גלגל עכבר או +/-</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="271"/>
+        <location filename="../src/window.cpp" line="268"/>
         <source>&lt;b&gt;Move Cursor:&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="272"/>
+        <location filename="../src/window.cpp" line="269"/>
         <source>Move mouse or W,A,D,S</source>
         <translation>הזזת עכבר או W,A,D,S</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="285"/>
+        <location filename="../src/window.cpp" line="282"/>
         <source>About Tetzle</source>
         <translation>אודות Tetzle</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="287"/>
+        <location filename="../src/window.cpp" line="284"/>
         <source>A jigsaw puzzle with tetrominoes for pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="288"/>
+        <location filename="../src/window.cpp" line="285"/>
         <source>Copyright &amp;copy; 2008-%1 Graeme Gott</source>
         <translation>Copyright &amp;copy; 2008-%1 Graeme Gott</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="289"/>
+        <location filename="../src/window.cpp" line="286"/>
         <source>Released under the &lt;a href=%1&gt;GPL 3&lt;/a&gt; license</source>
         <translation>משוחרר תחת הרשיון ‫&lt;a href=%1&gt;GPL 3&lt;/a&gt;</translation>
     </message>
@@ -550,12 +555,12 @@ There are saved games using this image that will also be removed.</source>
 <context>
     <name>ZoomSlider</name>
     <message>
-        <location filename="../src/zoom_slider.cpp" line="38"/>
+        <location filename="../src/zoom_slider.cpp" line="40"/>
         <source>??%</source>
         <translation>??%</translation>
     </message>
     <message>
-        <location filename="../src/zoom_slider.cpp" line="63"/>
+        <location filename="../src/zoom_slider.cpp" line="65"/>
         <source>%1%</source>
         <translation>%1%</translation>
     </message>

--- a/translations/tetzle_lt.ts
+++ b/translations/tetzle_lt.ts
@@ -4,7 +4,7 @@
 <context>
     <name>AddImage</name>
     <message>
-        <location filename="../src/add_image.cpp" line="87"/>
+        <location filename="../src/add_image.cpp" line="79"/>
         <source>Open Image</source>
         <translation type="unfinished"></translation>
     </message>
@@ -32,22 +32,27 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="77"/>
+        <location filename="../src/appearance_dialog.cpp" line="76"/>
+        <source>Success message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/appearance_dialog.cpp" line="79"/>
         <source>Colors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="96"/>
+        <location filename="../src/appearance_dialog.cpp" line="98"/>
         <source>Background:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="97"/>
+        <location filename="../src/appearance_dialog.cpp" line="99"/>
         <source>Shadow:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="98"/>
+        <location filename="../src/appearance_dialog.cpp" line="100"/>
         <source>Highlight:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -55,81 +60,81 @@
 <context>
     <name>Board</name>
     <message>
-        <location filename="../src/board.cpp" line="187"/>
-        <location filename="../src/board.cpp" line="293"/>
-        <location filename="../src/board.cpp" line="361"/>
+        <location filename="../src/board.cpp" line="190"/>
+        <location filename="../src/board.cpp" line="301"/>
+        <location filename="../src/board.cpp" line="369"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="187"/>
-        <location filename="../src/board.cpp" line="293"/>
+        <location filename="../src/board.cpp" line="190"/>
+        <location filename="../src/board.cpp" line="301"/>
         <source>Missing image.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="194"/>
-        <location filename="../src/board.cpp" line="269"/>
-        <location filename="../src/main.cpp" line="167"/>
+        <location filename="../src/board.cpp" line="197"/>
+        <location filename="../src/board.cpp" line="277"/>
+        <location filename="../src/main.cpp" line="162"/>
         <source>Please Wait</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="216"/>
-        <location filename="../src/board.cpp" line="368"/>
+        <location filename="../src/board.cpp" line="219"/>
+        <location filename="../src/board.cpp" line="376"/>
         <source>Loading image...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="222"/>
+        <location filename="../src/board.cpp" line="225"/>
         <source>Generating puzzle...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="228"/>
-        <location filename="../src/board.cpp" line="242"/>
+        <location filename="../src/board.cpp" line="236"/>
+        <location filename="../src/board.cpp" line="250"/>
         <source>Creating pieces...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="281"/>
+        <location filename="../src/board.cpp" line="289"/>
         <source>Loading puzzle...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="306"/>
+        <location filename="../src/board.cpp" line="314"/>
         <source>Unknown data format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="356"/>
+        <location filename="../src/board.cpp" line="364"/>
         <source>Unknown element &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="361"/>
+        <location filename="../src/board.cpp" line="369"/>
         <source>Error parsing XML file.
 
 %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="372"/>
+        <location filename="../src/board.cpp" line="380"/>
         <source>Loading pieces...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="454"/>
+        <location filename="../src/board.cpp" line="462"/>
         <source>Retrieving pieces...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="994"/>
+        <location filename="../src/board.cpp" line="1002"/>
         <source>Placing pieces...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="1326"/>
+        <location filename="../src/board.cpp" line="1331"/>
         <source>Success</source>
         <translation type="unfinished"></translation>
     </message>
@@ -173,22 +178,22 @@
 <context>
     <name>LocaleDialog</name>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="50"/>
+        <location filename="../src/locale_dialog.cpp" line="52"/>
         <source>Select application language:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="53"/>
+        <location filename="../src/locale_dialog.cpp" line="55"/>
         <source>&lt;System Language&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="183"/>
+        <location filename="../src/locale_dialog.cpp" line="172"/>
         <source>Note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="183"/>
+        <location filename="../src/locale_dialog.cpp" line="172"/>
         <source>Please restart this application for the change in language to take effect.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -196,51 +201,51 @@
 <context>
     <name>NewGameTab</name>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="105"/>
+        <location filename="../src/new_game_tab.cpp" line="106"/>
         <source>Add Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="109"/>
-        <location filename="../src/new_game_tab.cpp" line="290"/>
+        <location filename="../src/new_game_tab.cpp" line="110"/>
+        <location filename="../src/new_game_tab.cpp" line="291"/>
         <source>Remove Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="113"/>
+        <location filename="../src/new_game_tab.cpp" line="114"/>
         <source>Image Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="132"/>
-        <location filename="../src/new_game_tab.cpp" line="383"/>
+        <location filename="../src/new_game_tab.cpp" line="133"/>
+        <location filename="../src/new_game_tab.cpp" line="384"/>
         <source>%L1 pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="193"/>
+        <location filename="../src/new_game_tab.cpp" line="194"/>
         <source>Copying images...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="193"/>
+        <location filename="../src/new_game_tab.cpp" line="194"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="286"/>
+        <location filename="../src/new_game_tab.cpp" line="287"/>
         <source>Remove selected image?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="288"/>
+        <location filename="../src/new_game_tab.cpp" line="289"/>
         <source>Remove selected image?
 
 There are saved games using this image that will also be removed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="493"/>
+        <location filename="../src/new_game_tab.cpp" line="494"/>
         <source>Untitled</source>
         <translation type="unfinished"></translation>
     </message>
@@ -276,7 +281,7 @@ There are saved games using this image that will also be removed.</source>
 <context>
     <name>Overview</name>
     <message>
-        <location filename="../src/overview.cpp" line="38"/>
+        <location filename="../src/overview.cpp" line="39"/>
         <source>Overview</source>
         <translation type="unfinished"></translation>
     </message>
@@ -332,215 +337,215 @@ There are saved games using this image that will also be removed.</source>
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/main.cpp" line="168"/>
-        <location filename="../src/window.cpp" line="50"/>
-        <location filename="../src/window.cpp" line="286"/>
+        <location filename="../src/main.cpp" line="56"/>
+        <location filename="../src/main.cpp" line="163"/>
+        <location filename="../src/window.cpp" line="283"/>
         <source>Tetzle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="80"/>
+        <location filename="../src/window.cpp" line="79"/>
         <source>&amp;Game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="84"/>
+        <location filename="../src/window.cpp" line="83"/>
         <source>&amp;Retrieve Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="84"/>
+        <location filename="../src/window.cpp" line="83"/>
         <source>Ctrl+R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="88"/>
+        <location filename="../src/window.cpp" line="87"/>
         <source>&amp;Quit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="81"/>
+        <location filename="../src/window.cpp" line="80"/>
         <source>&amp;Choose...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="91"/>
+        <location filename="../src/window.cpp" line="90"/>
         <source>&amp;View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="92"/>
+        <location filename="../src/window.cpp" line="91"/>
         <source>Zoom &amp;In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="92"/>
+        <location filename="../src/window.cpp" line="91"/>
         <source>+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="95"/>
+        <location filename="../src/window.cpp" line="94"/>
         <source>Zoom &amp;Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="95"/>
+        <location filename="../src/window.cpp" line="94"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="98"/>
+        <location filename="../src/window.cpp" line="97"/>
         <source>Best &amp;Fit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="101"/>
+        <location filename="../src/window.cpp" line="100"/>
         <source>Show O&amp;verview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="101"/>
+        <location filename="../src/window.cpp" line="100"/>
         <source>Tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="107"/>
+        <location filename="../src/window.cpp" line="106"/>
         <source>F&amp;ullscreen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="111"/>
+        <location filename="../src/window.cpp" line="110"/>
         <source>F11</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="113"/>
+        <location filename="../src/window.cpp" line="112"/>
         <source>Ctrl+F</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="116"/>
+        <location filename="../src/window.cpp" line="115"/>
         <source>&amp;Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="117"/>
+        <location filename="../src/window.cpp" line="116"/>
         <source>&amp;Appearance...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="118"/>
+        <location filename="../src/window.cpp" line="117"/>
         <source>&amp;Language...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="120"/>
+        <location filename="../src/window.cpp" line="119"/>
         <source>&amp;Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="121"/>
+        <location filename="../src/window.cpp" line="120"/>
         <source>&amp;Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="123"/>
+        <location filename="../src/window.cpp" line="122"/>
         <source>&amp;About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="125"/>
+        <location filename="../src/window.cpp" line="124"/>
         <source>About &amp;Qt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="252"/>
+        <location filename="../src/window.cpp" line="249"/>
         <source>Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="259"/>
+        <location filename="../src/window.cpp" line="256"/>
         <source>&lt;b&gt;Pick Up Pieces:&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="260"/>
-        <location filename="../src/window.cpp" line="262"/>
+        <location filename="../src/window.cpp" line="257"/>
+        <location filename="../src/window.cpp" line="259"/>
         <source>Left Click or Space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="261"/>
+        <location filename="../src/window.cpp" line="258"/>
         <source>&lt;b&gt;Drop Pieces:&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="263"/>
+        <location filename="../src/window.cpp" line="260"/>
         <source>&lt;b&gt;Select Pieces:&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="264"/>
+        <location filename="../src/window.cpp" line="261"/>
         <source>Left Drag</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="265"/>
+        <location filename="../src/window.cpp" line="262"/>
         <source>&lt;b&gt;Rotate Pieces:&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="266"/>
+        <location filename="../src/window.cpp" line="263"/>
         <source>Right Click, Control + Left Click, or R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="267"/>
+        <location filename="../src/window.cpp" line="264"/>
         <source>&lt;b&gt;Drag Puzzle:&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="268"/>
+        <location filename="../src/window.cpp" line="265"/>
         <source>Middle Click, Shift + Left Click, or Arrows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="269"/>
+        <location filename="../src/window.cpp" line="266"/>
         <source>&lt;b&gt;Zoom Puzzle:&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="270"/>
+        <location filename="../src/window.cpp" line="267"/>
         <source>Scrollwheel or +/-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="271"/>
+        <location filename="../src/window.cpp" line="268"/>
         <source>&lt;b&gt;Move Cursor:&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="272"/>
+        <location filename="../src/window.cpp" line="269"/>
         <source>Move mouse or W,A,D,S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="285"/>
+        <location filename="../src/window.cpp" line="282"/>
         <source>About Tetzle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="287"/>
+        <location filename="../src/window.cpp" line="284"/>
         <source>A jigsaw puzzle with tetrominoes for pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="288"/>
+        <location filename="../src/window.cpp" line="285"/>
         <source>Copyright &amp;copy; 2008-%1 Graeme Gott</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="289"/>
+        <location filename="../src/window.cpp" line="286"/>
         <source>Released under the &lt;a href=%1&gt;GPL 3&lt;/a&gt; license</source>
         <translation type="unfinished"></translation>
     </message>
@@ -548,12 +553,12 @@ There are saved games using this image that will also be removed.</source>
 <context>
     <name>ZoomSlider</name>
     <message>
-        <location filename="../src/zoom_slider.cpp" line="38"/>
+        <location filename="../src/zoom_slider.cpp" line="40"/>
         <source>??%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/zoom_slider.cpp" line="63"/>
+        <location filename="../src/zoom_slider.cpp" line="65"/>
         <source>%1%</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/tetzle_lv.ts
+++ b/translations/tetzle_lv.ts
@@ -4,7 +4,7 @@
 <context>
     <name>AddImage</name>
     <message>
-        <location filename="../src/add_image.cpp" line="87"/>
+        <location filename="../src/add_image.cpp" line="79"/>
         <source>Open Image</source>
         <translation>Atvērt attēlu</translation>
     </message>
@@ -32,22 +32,27 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="77"/>
+        <location filename="../src/appearance_dialog.cpp" line="76"/>
+        <source>Success message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/appearance_dialog.cpp" line="79"/>
         <source>Colors</source>
         <translation>Krāsas</translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="96"/>
+        <location filename="../src/appearance_dialog.cpp" line="98"/>
         <source>Background:</source>
         <translation>Fons:</translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="97"/>
+        <location filename="../src/appearance_dialog.cpp" line="99"/>
         <source>Shadow:</source>
         <translation>Ēna:</translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="98"/>
+        <location filename="../src/appearance_dialog.cpp" line="100"/>
         <source>Highlight:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -55,81 +60,81 @@
 <context>
     <name>Board</name>
     <message>
-        <location filename="../src/board.cpp" line="187"/>
-        <location filename="../src/board.cpp" line="293"/>
-        <location filename="../src/board.cpp" line="361"/>
+        <location filename="../src/board.cpp" line="190"/>
+        <location filename="../src/board.cpp" line="301"/>
+        <location filename="../src/board.cpp" line="369"/>
         <source>Error</source>
         <translation>Kļūda</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="187"/>
-        <location filename="../src/board.cpp" line="293"/>
+        <location filename="../src/board.cpp" line="190"/>
+        <location filename="../src/board.cpp" line="301"/>
         <source>Missing image.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="194"/>
-        <location filename="../src/board.cpp" line="269"/>
-        <location filename="../src/main.cpp" line="167"/>
+        <location filename="../src/board.cpp" line="197"/>
+        <location filename="../src/board.cpp" line="277"/>
+        <location filename="../src/main.cpp" line="162"/>
         <source>Please Wait</source>
         <translation>Lūdzu, uzgaidiet</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="216"/>
-        <location filename="../src/board.cpp" line="368"/>
+        <location filename="../src/board.cpp" line="219"/>
+        <location filename="../src/board.cpp" line="376"/>
         <source>Loading image...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="222"/>
+        <location filename="../src/board.cpp" line="225"/>
         <source>Generating puzzle...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="228"/>
-        <location filename="../src/board.cpp" line="242"/>
+        <location filename="../src/board.cpp" line="236"/>
+        <location filename="../src/board.cpp" line="250"/>
         <source>Creating pieces...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="281"/>
+        <location filename="../src/board.cpp" line="289"/>
         <source>Loading puzzle...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="306"/>
+        <location filename="../src/board.cpp" line="314"/>
         <source>Unknown data format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="356"/>
+        <location filename="../src/board.cpp" line="364"/>
         <source>Unknown element &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="361"/>
+        <location filename="../src/board.cpp" line="369"/>
         <source>Error parsing XML file.
 
 %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="372"/>
+        <location filename="../src/board.cpp" line="380"/>
         <source>Loading pieces...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="454"/>
+        <location filename="../src/board.cpp" line="462"/>
         <source>Retrieving pieces...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="994"/>
+        <location filename="../src/board.cpp" line="1002"/>
         <source>Placing pieces...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="1326"/>
+        <location filename="../src/board.cpp" line="1331"/>
         <source>Success</source>
         <translation type="unfinished"></translation>
     </message>
@@ -173,22 +178,22 @@
 <context>
     <name>LocaleDialog</name>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="50"/>
+        <location filename="../src/locale_dialog.cpp" line="52"/>
         <source>Select application language:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="53"/>
+        <location filename="../src/locale_dialog.cpp" line="55"/>
         <source>&lt;System Language&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="183"/>
+        <location filename="../src/locale_dialog.cpp" line="172"/>
         <source>Note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="183"/>
+        <location filename="../src/locale_dialog.cpp" line="172"/>
         <source>Please restart this application for the change in language to take effect.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -196,51 +201,51 @@
 <context>
     <name>NewGameTab</name>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="105"/>
+        <location filename="../src/new_game_tab.cpp" line="106"/>
         <source>Add Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="109"/>
-        <location filename="../src/new_game_tab.cpp" line="290"/>
+        <location filename="../src/new_game_tab.cpp" line="110"/>
+        <location filename="../src/new_game_tab.cpp" line="291"/>
         <source>Remove Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="113"/>
+        <location filename="../src/new_game_tab.cpp" line="114"/>
         <source>Image Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="132"/>
-        <location filename="../src/new_game_tab.cpp" line="383"/>
+        <location filename="../src/new_game_tab.cpp" line="133"/>
+        <location filename="../src/new_game_tab.cpp" line="384"/>
         <source>%L1 pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="193"/>
+        <location filename="../src/new_game_tab.cpp" line="194"/>
         <source>Copying images...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="193"/>
+        <location filename="../src/new_game_tab.cpp" line="194"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="286"/>
+        <location filename="../src/new_game_tab.cpp" line="287"/>
         <source>Remove selected image?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="288"/>
+        <location filename="../src/new_game_tab.cpp" line="289"/>
         <source>Remove selected image?
 
 There are saved games using this image that will also be removed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="493"/>
+        <location filename="../src/new_game_tab.cpp" line="494"/>
         <source>Untitled</source>
         <translation type="unfinished"></translation>
     </message>
@@ -276,7 +281,7 @@ There are saved games using this image that will also be removed.</source>
 <context>
     <name>Overview</name>
     <message>
-        <location filename="../src/overview.cpp" line="38"/>
+        <location filename="../src/overview.cpp" line="39"/>
         <source>Overview</source>
         <translation type="unfinished"></translation>
     </message>
@@ -332,215 +337,215 @@ There are saved games using this image that will also be removed.</source>
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/main.cpp" line="168"/>
-        <location filename="../src/window.cpp" line="50"/>
-        <location filename="../src/window.cpp" line="286"/>
+        <location filename="../src/main.cpp" line="56"/>
+        <location filename="../src/main.cpp" line="163"/>
+        <location filename="../src/window.cpp" line="283"/>
         <source>Tetzle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="80"/>
+        <location filename="../src/window.cpp" line="79"/>
         <source>&amp;Game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="84"/>
+        <location filename="../src/window.cpp" line="83"/>
         <source>&amp;Retrieve Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="84"/>
+        <location filename="../src/window.cpp" line="83"/>
         <source>Ctrl+R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="88"/>
+        <location filename="../src/window.cpp" line="87"/>
         <source>&amp;Quit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="81"/>
+        <location filename="../src/window.cpp" line="80"/>
         <source>&amp;Choose...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="91"/>
+        <location filename="../src/window.cpp" line="90"/>
         <source>&amp;View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="92"/>
+        <location filename="../src/window.cpp" line="91"/>
         <source>Zoom &amp;In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="92"/>
+        <location filename="../src/window.cpp" line="91"/>
         <source>+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="95"/>
+        <location filename="../src/window.cpp" line="94"/>
         <source>Zoom &amp;Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="95"/>
+        <location filename="../src/window.cpp" line="94"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="98"/>
+        <location filename="../src/window.cpp" line="97"/>
         <source>Best &amp;Fit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="101"/>
+        <location filename="../src/window.cpp" line="100"/>
         <source>Show O&amp;verview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="101"/>
+        <location filename="../src/window.cpp" line="100"/>
         <source>Tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="107"/>
+        <location filename="../src/window.cpp" line="106"/>
         <source>F&amp;ullscreen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="111"/>
+        <location filename="../src/window.cpp" line="110"/>
         <source>F11</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="113"/>
+        <location filename="../src/window.cpp" line="112"/>
         <source>Ctrl+F</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="116"/>
+        <location filename="../src/window.cpp" line="115"/>
         <source>&amp;Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="117"/>
+        <location filename="../src/window.cpp" line="116"/>
         <source>&amp;Appearance...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="118"/>
+        <location filename="../src/window.cpp" line="117"/>
         <source>&amp;Language...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="120"/>
+        <location filename="../src/window.cpp" line="119"/>
         <source>&amp;Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="121"/>
+        <location filename="../src/window.cpp" line="120"/>
         <source>&amp;Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="123"/>
+        <location filename="../src/window.cpp" line="122"/>
         <source>&amp;About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="125"/>
+        <location filename="../src/window.cpp" line="124"/>
         <source>About &amp;Qt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="252"/>
+        <location filename="../src/window.cpp" line="249"/>
         <source>Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="259"/>
+        <location filename="../src/window.cpp" line="256"/>
         <source>&lt;b&gt;Pick Up Pieces:&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="260"/>
-        <location filename="../src/window.cpp" line="262"/>
+        <location filename="../src/window.cpp" line="257"/>
+        <location filename="../src/window.cpp" line="259"/>
         <source>Left Click or Space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="261"/>
+        <location filename="../src/window.cpp" line="258"/>
         <source>&lt;b&gt;Drop Pieces:&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="263"/>
+        <location filename="../src/window.cpp" line="260"/>
         <source>&lt;b&gt;Select Pieces:&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="264"/>
+        <location filename="../src/window.cpp" line="261"/>
         <source>Left Drag</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="265"/>
+        <location filename="../src/window.cpp" line="262"/>
         <source>&lt;b&gt;Rotate Pieces:&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="266"/>
+        <location filename="../src/window.cpp" line="263"/>
         <source>Right Click, Control + Left Click, or R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="267"/>
+        <location filename="../src/window.cpp" line="264"/>
         <source>&lt;b&gt;Drag Puzzle:&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="268"/>
+        <location filename="../src/window.cpp" line="265"/>
         <source>Middle Click, Shift + Left Click, or Arrows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="269"/>
+        <location filename="../src/window.cpp" line="266"/>
         <source>&lt;b&gt;Zoom Puzzle:&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="270"/>
+        <location filename="../src/window.cpp" line="267"/>
         <source>Scrollwheel or +/-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="271"/>
+        <location filename="../src/window.cpp" line="268"/>
         <source>&lt;b&gt;Move Cursor:&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="272"/>
+        <location filename="../src/window.cpp" line="269"/>
         <source>Move mouse or W,A,D,S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="285"/>
+        <location filename="../src/window.cpp" line="282"/>
         <source>About Tetzle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="287"/>
+        <location filename="../src/window.cpp" line="284"/>
         <source>A jigsaw puzzle with tetrominoes for pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="288"/>
+        <location filename="../src/window.cpp" line="285"/>
         <source>Copyright &amp;copy; 2008-%1 Graeme Gott</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="289"/>
+        <location filename="../src/window.cpp" line="286"/>
         <source>Released under the &lt;a href=%1&gt;GPL 3&lt;/a&gt; license</source>
         <translation type="unfinished"></translation>
     </message>
@@ -548,12 +553,12 @@ There are saved games using this image that will also be removed.</source>
 <context>
     <name>ZoomSlider</name>
     <message>
-        <location filename="../src/zoom_slider.cpp" line="38"/>
+        <location filename="../src/zoom_slider.cpp" line="40"/>
         <source>??%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/zoom_slider.cpp" line="63"/>
+        <location filename="../src/zoom_slider.cpp" line="65"/>
         <source>%1%</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/tetzle_ms.ts
+++ b/translations/tetzle_ms.ts
@@ -4,7 +4,7 @@
 <context>
     <name>AddImage</name>
     <message>
-        <location filename="../src/add_image.cpp" line="87"/>
+        <location filename="../src/add_image.cpp" line="79"/>
         <source>Open Image</source>
         <translation>Buka Imej</translation>
     </message>
@@ -32,22 +32,27 @@
         <translation>Bayang letak</translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="77"/>
+        <location filename="../src/appearance_dialog.cpp" line="76"/>
+        <source>Success message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/appearance_dialog.cpp" line="79"/>
         <source>Colors</source>
         <translation>Warna</translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="96"/>
+        <location filename="../src/appearance_dialog.cpp" line="98"/>
         <source>Background:</source>
         <translation>Latar Belakang:</translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="97"/>
+        <location filename="../src/appearance_dialog.cpp" line="99"/>
         <source>Shadow:</source>
         <translation>Bayang:</translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="98"/>
+        <location filename="../src/appearance_dialog.cpp" line="100"/>
         <source>Highlight:</source>
         <translation>Sorot:</translation>
     </message>
@@ -55,59 +60,59 @@
 <context>
     <name>Board</name>
     <message>
-        <location filename="../src/board.cpp" line="187"/>
-        <location filename="../src/board.cpp" line="293"/>
-        <location filename="../src/board.cpp" line="361"/>
+        <location filename="../src/board.cpp" line="190"/>
+        <location filename="../src/board.cpp" line="301"/>
+        <location filename="../src/board.cpp" line="369"/>
         <source>Error</source>
         <translation>Ralat</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="187"/>
-        <location filename="../src/board.cpp" line="293"/>
+        <location filename="../src/board.cpp" line="190"/>
+        <location filename="../src/board.cpp" line="301"/>
         <source>Missing image.</source>
         <translation>Imej hilang.</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="194"/>
-        <location filename="../src/board.cpp" line="269"/>
-        <location filename="../src/main.cpp" line="167"/>
+        <location filename="../src/board.cpp" line="197"/>
+        <location filename="../src/board.cpp" line="277"/>
+        <location filename="../src/main.cpp" line="162"/>
         <source>Please Wait</source>
         <translation>Tunggu Sebentar</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="216"/>
-        <location filename="../src/board.cpp" line="368"/>
+        <location filename="../src/board.cpp" line="219"/>
+        <location filename="../src/board.cpp" line="376"/>
         <source>Loading image...</source>
         <translation>Memuatkan imej...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="222"/>
+        <location filename="../src/board.cpp" line="225"/>
         <source>Generating puzzle...</source>
         <translation>Menjana teka-teki...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="228"/>
-        <location filename="../src/board.cpp" line="242"/>
+        <location filename="../src/board.cpp" line="236"/>
+        <location filename="../src/board.cpp" line="250"/>
         <source>Creating pieces...</source>
         <translation>Mencipta kepingan...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="281"/>
+        <location filename="../src/board.cpp" line="289"/>
         <source>Loading puzzle...</source>
         <translation>Memuatkan teka-teki...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="306"/>
+        <location filename="../src/board.cpp" line="314"/>
         <source>Unknown data format</source>
         <translation>Format data tidak diketahui</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="356"/>
+        <location filename="../src/board.cpp" line="364"/>
         <source>Unknown element &apos;%1&apos;</source>
         <translation>Unsur &apos;%1&apos; tidak diketahui</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="361"/>
+        <location filename="../src/board.cpp" line="369"/>
         <source>Error parsing XML file.
 
 %1</source>
@@ -116,22 +121,22 @@
 %1</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="372"/>
+        <location filename="../src/board.cpp" line="380"/>
         <source>Loading pieces...</source>
         <translation>Memuatkan kepingan...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="454"/>
+        <location filename="../src/board.cpp" line="462"/>
         <source>Retrieving pieces...</source>
         <translation>Mendapatkan kepingan...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="994"/>
+        <location filename="../src/board.cpp" line="1002"/>
         <source>Placing pieces...</source>
         <translation>Meletak kepingan...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="1326"/>
+        <location filename="../src/board.cpp" line="1331"/>
         <source>Success</source>
         <translation>Berjaya</translation>
     </message>
@@ -175,22 +180,22 @@
 <context>
     <name>LocaleDialog</name>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="50"/>
+        <location filename="../src/locale_dialog.cpp" line="52"/>
         <source>Select application language:</source>
         <translation>Pilih bahasa aplikasi:</translation>
     </message>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="53"/>
+        <location filename="../src/locale_dialog.cpp" line="55"/>
         <source>&lt;System Language&gt;</source>
         <translation>&lt;Bahasa Sistem&gt;</translation>
     </message>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="183"/>
+        <location filename="../src/locale_dialog.cpp" line="172"/>
         <source>Note</source>
         <translation>Nota</translation>
     </message>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="183"/>
+        <location filename="../src/locale_dialog.cpp" line="172"/>
         <source>Please restart this application for the change in language to take effect.</source>
         <translation>Sila mulakan semula aplikasi ini supaya perubahan bahasa berkesan.</translation>
     </message>
@@ -198,44 +203,44 @@
 <context>
     <name>NewGameTab</name>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="105"/>
+        <location filename="../src/new_game_tab.cpp" line="106"/>
         <source>Add Image</source>
         <translation>Tambah Imej</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="109"/>
-        <location filename="../src/new_game_tab.cpp" line="290"/>
+        <location filename="../src/new_game_tab.cpp" line="110"/>
+        <location filename="../src/new_game_tab.cpp" line="291"/>
         <source>Remove Image</source>
         <translation>Buang Imej</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="113"/>
+        <location filename="../src/new_game_tab.cpp" line="114"/>
         <source>Image Properties</source>
         <translation>Sifat Imej</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="132"/>
-        <location filename="../src/new_game_tab.cpp" line="383"/>
+        <location filename="../src/new_game_tab.cpp" line="133"/>
+        <location filename="../src/new_game_tab.cpp" line="384"/>
         <source>%L1 pieces</source>
         <translation>%L1 kepingan</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="193"/>
+        <location filename="../src/new_game_tab.cpp" line="194"/>
         <source>Copying images...</source>
         <translation>Menyalin imej...</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="193"/>
+        <location filename="../src/new_game_tab.cpp" line="194"/>
         <source>Cancel</source>
         <translation>Batal</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="286"/>
+        <location filename="../src/new_game_tab.cpp" line="287"/>
         <source>Remove selected image?</source>
         <translation>Buang imej terpilih?</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="288"/>
+        <location filename="../src/new_game_tab.cpp" line="289"/>
         <source>Remove selected image?
 
 There are saved games using this image that will also be removed.</source>
@@ -244,7 +249,7 @@ There are saved games using this image that will also be removed.</source>
 Terdapat permainan tersimpan menggunakan imej ini yang mana juga dibuang.</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="493"/>
+        <location filename="../src/new_game_tab.cpp" line="494"/>
         <source>Untitled</source>
         <translation>Tidak Bertajuk</translation>
     </message>
@@ -280,7 +285,7 @@ Terdapat permainan tersimpan menggunakan imej ini yang mana juga dibuang.</trans
 <context>
     <name>Overview</name>
     <message>
-        <location filename="../src/overview.cpp" line="38"/>
+        <location filename="../src/overview.cpp" line="39"/>
         <source>Overview</source>
         <translation>Tinjauan</translation>
     </message>
@@ -336,215 +341,215 @@ Terdapat permainan tersimpan menggunakan imej ini yang mana juga dibuang.</trans
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/main.cpp" line="168"/>
-        <location filename="../src/window.cpp" line="50"/>
-        <location filename="../src/window.cpp" line="286"/>
+        <location filename="../src/main.cpp" line="56"/>
+        <location filename="../src/main.cpp" line="163"/>
+        <location filename="../src/window.cpp" line="283"/>
         <source>Tetzle</source>
         <translation>Tetzle</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="80"/>
+        <location filename="../src/window.cpp" line="79"/>
         <source>&amp;Game</source>
         <translation>&amp;Permainan</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="84"/>
+        <location filename="../src/window.cpp" line="83"/>
         <source>&amp;Retrieve Pieces</source>
         <translation>&amp;Dapatkan Kepingan</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="84"/>
+        <location filename="../src/window.cpp" line="83"/>
         <source>Ctrl+R</source>
         <translation>Ctrl+R</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="88"/>
+        <location filename="../src/window.cpp" line="87"/>
         <source>&amp;Quit</source>
         <translation>&amp;Keluar</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="81"/>
+        <location filename="../src/window.cpp" line="80"/>
         <source>&amp;Choose...</source>
         <translation>P&amp;ilih...</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="91"/>
+        <location filename="../src/window.cpp" line="90"/>
         <source>&amp;View</source>
         <translation>&amp;Lihat</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="92"/>
+        <location filename="../src/window.cpp" line="91"/>
         <source>Zoom &amp;In</source>
         <translation>Zum &amp;Masuk</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="92"/>
+        <location filename="../src/window.cpp" line="91"/>
         <source>+</source>
         <translation>+</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="95"/>
+        <location filename="../src/window.cpp" line="94"/>
         <source>Zoom &amp;Out</source>
         <translation>Zum &amp;Keluar</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="95"/>
+        <location filename="../src/window.cpp" line="94"/>
         <source>-</source>
         <translation>-</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="98"/>
+        <location filename="../src/window.cpp" line="97"/>
         <source>Best &amp;Fit</source>
         <translation>Suai M&amp;uat</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="101"/>
+        <location filename="../src/window.cpp" line="100"/>
         <source>Show O&amp;verview</source>
         <translation>Tunjuk T&amp;injauan</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="101"/>
+        <location filename="../src/window.cpp" line="100"/>
         <source>Tab</source>
         <translation>Tab</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="107"/>
+        <location filename="../src/window.cpp" line="106"/>
         <source>F&amp;ullscreen</source>
         <translation>Sk&amp;rin Penuh</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="111"/>
+        <location filename="../src/window.cpp" line="110"/>
         <source>F11</source>
         <translation>F11</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="113"/>
+        <location filename="../src/window.cpp" line="112"/>
         <source>Ctrl+F</source>
         <translation>Ctrl+F</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="116"/>
+        <location filename="../src/window.cpp" line="115"/>
         <source>&amp;Settings</source>
         <translation>&amp;Tetapan</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="117"/>
+        <location filename="../src/window.cpp" line="116"/>
         <source>&amp;Appearance...</source>
         <translation>P&amp;enampilan...</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="118"/>
+        <location filename="../src/window.cpp" line="117"/>
         <source>&amp;Language...</source>
         <translation>&amp;Bahasa...</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="120"/>
+        <location filename="../src/window.cpp" line="119"/>
         <source>&amp;Help</source>
         <translation>Ba&amp;ntuan</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="121"/>
+        <location filename="../src/window.cpp" line="120"/>
         <source>&amp;Controls</source>
         <translation>&amp;Kawalan</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="123"/>
+        <location filename="../src/window.cpp" line="122"/>
         <source>&amp;About</source>
         <translation>Perih&amp;al</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="125"/>
+        <location filename="../src/window.cpp" line="124"/>
         <source>About &amp;Qt</source>
         <translation>Perihal &amp;Qt</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="252"/>
+        <location filename="../src/window.cpp" line="249"/>
         <source>Controls</source>
         <translation>Kawalan</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="259"/>
+        <location filename="../src/window.cpp" line="256"/>
         <source>&lt;b&gt;Pick Up Pieces:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Ambil Kepingan:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="260"/>
-        <location filename="../src/window.cpp" line="262"/>
+        <location filename="../src/window.cpp" line="257"/>
+        <location filename="../src/window.cpp" line="259"/>
         <source>Left Click or Space</source>
         <translation>Klik Kiri atau Space</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="261"/>
+        <location filename="../src/window.cpp" line="258"/>
         <source>&lt;b&gt;Drop Pieces:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Lepas Kepingan:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="263"/>
+        <location filename="../src/window.cpp" line="260"/>
         <source>&lt;b&gt;Select Pieces:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Pilih Kepingan:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="264"/>
+        <location filename="../src/window.cpp" line="261"/>
         <source>Left Drag</source>
         <translation>Seret Kiri</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="265"/>
+        <location filename="../src/window.cpp" line="262"/>
         <source>&lt;b&gt;Rotate Pieces:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Putar Kepingan:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="266"/>
+        <location filename="../src/window.cpp" line="263"/>
         <source>Right Click, Control + Left Click, or R</source>
         <translation>Klik Kanan, Control + Klik Kiri, atau R</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="267"/>
+        <location filename="../src/window.cpp" line="264"/>
         <source>&lt;b&gt;Drag Puzzle:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Seret Teka-teki:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="268"/>
+        <location filename="../src/window.cpp" line="265"/>
         <source>Middle Click, Shift + Left Click, or Arrows</source>
         <translation>Klik Tengah, Shift + Klik Kiri, atau Anak Panah</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="269"/>
+        <location filename="../src/window.cpp" line="266"/>
         <source>&lt;b&gt;Zoom Puzzle:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Zum Teka-teki:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="270"/>
+        <location filename="../src/window.cpp" line="267"/>
         <source>Scrollwheel or +/-</source>
         <translation>Roda Tatal atau +/-</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="271"/>
+        <location filename="../src/window.cpp" line="268"/>
         <source>&lt;b&gt;Move Cursor:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Gerak Kursor:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="272"/>
+        <location filename="../src/window.cpp" line="269"/>
         <source>Move mouse or W,A,D,S</source>
         <translation>Gerak tetikus atau </translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="285"/>
+        <location filename="../src/window.cpp" line="282"/>
         <source>About Tetzle</source>
         <translation>Perihal Tetzle</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="287"/>
+        <location filename="../src/window.cpp" line="284"/>
         <source>A jigsaw puzzle with tetrominoes for pieces</source>
         <translation>Teka-teki susun suai gambar dengan tetromino untuk kepingannya</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="288"/>
+        <location filename="../src/window.cpp" line="285"/>
         <source>Copyright &amp;copy; 2008-%1 Graeme Gott</source>
         <translation>Hakcipta &amp;copy; 2008-%1 Graeme Gott</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="289"/>
+        <location filename="../src/window.cpp" line="286"/>
         <source>Released under the &lt;a href=%1&gt;GPL 3&lt;/a&gt; license</source>
         <translation>Dikeluarkan dibawah lesen &lt;a href=%1&gt;GPL 3&lt;/a&gt;</translation>
     </message>
@@ -552,12 +557,12 @@ Terdapat permainan tersimpan menggunakan imej ini yang mana juga dibuang.</trans
 <context>
     <name>ZoomSlider</name>
     <message>
-        <location filename="../src/zoom_slider.cpp" line="38"/>
+        <location filename="../src/zoom_slider.cpp" line="40"/>
         <source>??%</source>
         <translation>??%</translation>
     </message>
     <message>
-        <location filename="../src/zoom_slider.cpp" line="63"/>
+        <location filename="../src/zoom_slider.cpp" line="65"/>
         <source>%1%</source>
         <translation>%1%</translation>
     </message>

--- a/translations/tetzle_nl.ts
+++ b/translations/tetzle_nl.ts
@@ -4,7 +4,7 @@
 <context>
     <name>AddImage</name>
     <message>
-        <location filename="../src/add_image.cpp" line="87"/>
+        <location filename="../src/add_image.cpp" line="79"/>
         <source>Open Image</source>
         <translation>Open plaatje</translation>
     </message>
@@ -32,22 +32,27 @@
         <translation>slagschaduwen</translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="77"/>
+        <location filename="../src/appearance_dialog.cpp" line="76"/>
+        <source>Success message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/appearance_dialog.cpp" line="79"/>
         <source>Colors</source>
         <translation>Kleuren</translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="96"/>
+        <location filename="../src/appearance_dialog.cpp" line="98"/>
         <source>Background:</source>
         <translation>Achtergrond</translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="97"/>
+        <location filename="../src/appearance_dialog.cpp" line="99"/>
         <source>Shadow:</source>
         <translation>Schaduw</translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="98"/>
+        <location filename="../src/appearance_dialog.cpp" line="100"/>
         <source>Highlight:</source>
         <translation>Markering:</translation>
     </message>
@@ -55,59 +60,59 @@
 <context>
     <name>Board</name>
     <message>
-        <location filename="../src/board.cpp" line="187"/>
-        <location filename="../src/board.cpp" line="293"/>
-        <location filename="../src/board.cpp" line="361"/>
+        <location filename="../src/board.cpp" line="190"/>
+        <location filename="../src/board.cpp" line="301"/>
+        <location filename="../src/board.cpp" line="369"/>
         <source>Error</source>
         <translation>Fout</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="187"/>
-        <location filename="../src/board.cpp" line="293"/>
+        <location filename="../src/board.cpp" line="190"/>
+        <location filename="../src/board.cpp" line="301"/>
         <source>Missing image.</source>
         <translation>Ontbrekend plaatje.</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="194"/>
-        <location filename="../src/board.cpp" line="269"/>
-        <location filename="../src/main.cpp" line="167"/>
+        <location filename="../src/board.cpp" line="197"/>
+        <location filename="../src/board.cpp" line="277"/>
+        <location filename="../src/main.cpp" line="162"/>
         <source>Please Wait</source>
         <translation>Graag wachten</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="216"/>
-        <location filename="../src/board.cpp" line="368"/>
+        <location filename="../src/board.cpp" line="219"/>
+        <location filename="../src/board.cpp" line="376"/>
         <source>Loading image...</source>
         <translation>Plaatje inladen...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="222"/>
+        <location filename="../src/board.cpp" line="225"/>
         <source>Generating puzzle...</source>
         <translation>Puzzelgeneratie loopt....</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="228"/>
-        <location filename="../src/board.cpp" line="242"/>
+        <location filename="../src/board.cpp" line="236"/>
+        <location filename="../src/board.cpp" line="250"/>
         <source>Creating pieces...</source>
         <translation>Stukken maken...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="281"/>
+        <location filename="../src/board.cpp" line="289"/>
         <source>Loading puzzle...</source>
         <translation>Puzzel laden...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="306"/>
+        <location filename="../src/board.cpp" line="314"/>
         <source>Unknown data format</source>
         <translation>Onbekend data formaat</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="356"/>
+        <location filename="../src/board.cpp" line="364"/>
         <source>Unknown element &apos;%1&apos;</source>
         <translation>Onbekend element &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="361"/>
+        <location filename="../src/board.cpp" line="369"/>
         <source>Error parsing XML file.
 
 %1</source>
@@ -116,22 +121,22 @@
 %1</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="372"/>
+        <location filename="../src/board.cpp" line="380"/>
         <source>Loading pieces...</source>
         <translation>Stukken laden...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="454"/>
+        <location filename="../src/board.cpp" line="462"/>
         <source>Retrieving pieces...</source>
         <translation>Stukken ophalen...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="994"/>
+        <location filename="../src/board.cpp" line="1002"/>
         <source>Placing pieces...</source>
         <translation>Stukken plaatsen...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="1326"/>
+        <location filename="../src/board.cpp" line="1331"/>
         <source>Success</source>
         <translation>Succes</translation>
     </message>
@@ -175,22 +180,22 @@
 <context>
     <name>LocaleDialog</name>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="50"/>
+        <location filename="../src/locale_dialog.cpp" line="52"/>
         <source>Select application language:</source>
         <translation>Selecteer taal van de applicatie</translation>
     </message>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="53"/>
+        <location filename="../src/locale_dialog.cpp" line="55"/>
         <source>&lt;System Language&gt;</source>
         <translation>&lt;systeemtaal&gt;</translation>
     </message>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="183"/>
+        <location filename="../src/locale_dialog.cpp" line="172"/>
         <source>Note</source>
         <translation>Notitie</translation>
     </message>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="183"/>
+        <location filename="../src/locale_dialog.cpp" line="172"/>
         <source>Please restart this application for the change in language to take effect.</source>
         <translation>Graag de applicatie herstarten om de taalwijziging door te voeren</translation>
     </message>
@@ -198,44 +203,44 @@
 <context>
     <name>NewGameTab</name>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="105"/>
+        <location filename="../src/new_game_tab.cpp" line="106"/>
         <source>Add Image</source>
         <translation>Plaatje toevoegen</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="109"/>
-        <location filename="../src/new_game_tab.cpp" line="290"/>
+        <location filename="../src/new_game_tab.cpp" line="110"/>
+        <location filename="../src/new_game_tab.cpp" line="291"/>
         <source>Remove Image</source>
         <translation>Verwijder plaatje</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="113"/>
+        <location filename="../src/new_game_tab.cpp" line="114"/>
         <source>Image Properties</source>
         <translation>Eigenschappen plaatje</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="132"/>
-        <location filename="../src/new_game_tab.cpp" line="383"/>
+        <location filename="../src/new_game_tab.cpp" line="133"/>
+        <location filename="../src/new_game_tab.cpp" line="384"/>
         <source>%L1 pieces</source>
         <translation>%L1 stukken</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="193"/>
+        <location filename="../src/new_game_tab.cpp" line="194"/>
         <source>Copying images...</source>
         <translation>Plaatjes kopieren...</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="193"/>
+        <location filename="../src/new_game_tab.cpp" line="194"/>
         <source>Cancel</source>
         <translation>Afbreken</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="286"/>
+        <location filename="../src/new_game_tab.cpp" line="287"/>
         <source>Remove selected image?</source>
         <translation>Verwijder geselecteerd plaatje?</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="288"/>
+        <location filename="../src/new_game_tab.cpp" line="289"/>
         <source>Remove selected image?
 
 There are saved games using this image that will also be removed.</source>
@@ -244,7 +249,7 @@ There are saved games using this image that will also be removed.</source>
 De opgeslagen spellen van dit plaatje worden ook verwijderd.</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="493"/>
+        <location filename="../src/new_game_tab.cpp" line="494"/>
         <source>Untitled</source>
         <translation>Naamloos</translation>
     </message>
@@ -280,7 +285,7 @@ De opgeslagen spellen van dit plaatje worden ook verwijderd.</translation>
 <context>
     <name>Overview</name>
     <message>
-        <location filename="../src/overview.cpp" line="38"/>
+        <location filename="../src/overview.cpp" line="39"/>
         <source>Overview</source>
         <translation>Overzicht</translation>
     </message>
@@ -336,215 +341,215 @@ De opgeslagen spellen van dit plaatje worden ook verwijderd.</translation>
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/main.cpp" line="168"/>
-        <location filename="../src/window.cpp" line="50"/>
-        <location filename="../src/window.cpp" line="286"/>
+        <location filename="../src/main.cpp" line="56"/>
+        <location filename="../src/main.cpp" line="163"/>
+        <location filename="../src/window.cpp" line="283"/>
         <source>Tetzle</source>
         <translation>Tetzle</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="80"/>
+        <location filename="../src/window.cpp" line="79"/>
         <source>&amp;Game</source>
         <translation>&amp;Spel</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="84"/>
+        <location filename="../src/window.cpp" line="83"/>
         <source>&amp;Retrieve Pieces</source>
         <translation>&amp;Stukken ophalen</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="84"/>
+        <location filename="../src/window.cpp" line="83"/>
         <source>Ctrl+R</source>
         <translation>Ctrl+R</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="88"/>
+        <location filename="../src/window.cpp" line="87"/>
         <source>&amp;Quit</source>
         <translation>&amp;Quit</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="81"/>
+        <location filename="../src/window.cpp" line="80"/>
         <source>&amp;Choose...</source>
         <translation>&amp;Kies...</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="91"/>
+        <location filename="../src/window.cpp" line="90"/>
         <source>&amp;View</source>
         <translation>&amp;Toon</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="92"/>
+        <location filename="../src/window.cpp" line="91"/>
         <source>Zoom &amp;In</source>
         <translation>&amp;Inzoomen</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="92"/>
+        <location filename="../src/window.cpp" line="91"/>
         <source>+</source>
         <translation>+</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="95"/>
+        <location filename="../src/window.cpp" line="94"/>
         <source>Zoom &amp;Out</source>
         <translation>&amp;Uitzoomen</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="95"/>
+        <location filename="../src/window.cpp" line="94"/>
         <source>-</source>
         <translation>-</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="98"/>
+        <location filename="../src/window.cpp" line="97"/>
         <source>Best &amp;Fit</source>
         <translation>&amp;Beste passing</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="101"/>
+        <location filename="../src/window.cpp" line="100"/>
         <source>Show O&amp;verview</source>
         <translation>&amp;Geef overzicht</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="101"/>
+        <location filename="../src/window.cpp" line="100"/>
         <source>Tab</source>
         <translation>Tab</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="107"/>
+        <location filename="../src/window.cpp" line="106"/>
         <source>F&amp;ullscreen</source>
         <translation>&amp;Volledig scherm</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="111"/>
+        <location filename="../src/window.cpp" line="110"/>
         <source>F11</source>
         <translation>F11</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="113"/>
+        <location filename="../src/window.cpp" line="112"/>
         <source>Ctrl+F</source>
         <translation>Ctrl+F</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="116"/>
+        <location filename="../src/window.cpp" line="115"/>
         <source>&amp;Settings</source>
         <translation>&amp;Instellingen</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="117"/>
+        <location filename="../src/window.cpp" line="116"/>
         <source>&amp;Appearance...</source>
         <translation>&amp;Weergave</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="118"/>
+        <location filename="../src/window.cpp" line="117"/>
         <source>&amp;Language...</source>
         <translation>&amp;Taal</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="120"/>
+        <location filename="../src/window.cpp" line="119"/>
         <source>&amp;Help</source>
         <translation>&amp;Help</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="121"/>
+        <location filename="../src/window.cpp" line="120"/>
         <source>&amp;Controls</source>
         <translation>&amp;Besturing</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="123"/>
+        <location filename="../src/window.cpp" line="122"/>
         <source>&amp;About</source>
         <translation>&amp;Over</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="125"/>
+        <location filename="../src/window.cpp" line="124"/>
         <source>About &amp;Qt</source>
         <translation>Over &amp;Wt</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="252"/>
+        <location filename="../src/window.cpp" line="249"/>
         <source>Controls</source>
         <translation>Besturing</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="259"/>
+        <location filename="../src/window.cpp" line="256"/>
         <source>&lt;b&gt;Pick Up Pieces:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Stukken oppakken:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="260"/>
-        <location filename="../src/window.cpp" line="262"/>
+        <location filename="../src/window.cpp" line="257"/>
+        <location filename="../src/window.cpp" line="259"/>
         <source>Left Click or Space</source>
         <translation>Linkerklik of spatie</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="261"/>
+        <location filename="../src/window.cpp" line="258"/>
         <source>&lt;b&gt;Drop Pieces:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Stukken plaatsen:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="263"/>
+        <location filename="../src/window.cpp" line="260"/>
         <source>&lt;b&gt;Select Pieces:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Selecteer stukken:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="264"/>
+        <location filename="../src/window.cpp" line="261"/>
         <source>Left Drag</source>
         <translation>Sleep links</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="265"/>
+        <location filename="../src/window.cpp" line="262"/>
         <source>&lt;b&gt;Rotate Pieces:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Roteer stukken:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="266"/>
+        <location filename="../src/window.cpp" line="263"/>
         <source>Right Click, Control + Left Click, or R</source>
         <translation>Rechtsklik, Control + linksklik, of R</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="267"/>
+        <location filename="../src/window.cpp" line="264"/>
         <source>&lt;b&gt;Drag Puzzle:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Sleep Puzzel:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="268"/>
+        <location filename="../src/window.cpp" line="265"/>
         <source>Middle Click, Shift + Left Click, or Arrows</source>
         <translation>Middenklik, Shift + linkerklik of pijltjes</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="269"/>
+        <location filename="../src/window.cpp" line="266"/>
         <source>&lt;b&gt;Zoom Puzzle:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Zoomen Puzzel:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="270"/>
+        <location filename="../src/window.cpp" line="267"/>
         <source>Scrollwheel or +/-</source>
         <translation>Scrollwheel of +/-</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="271"/>
+        <location filename="../src/window.cpp" line="268"/>
         <source>&lt;b&gt;Move Cursor:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Verplaats cursor:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="272"/>
+        <location filename="../src/window.cpp" line="269"/>
         <source>Move mouse or W,A,D,S</source>
         <translation>Verplaats muis of W,A,D,S</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="285"/>
+        <location filename="../src/window.cpp" line="282"/>
         <source>About Tetzle</source>
         <translation>Over Tetzle</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="287"/>
+        <location filename="../src/window.cpp" line="284"/>
         <source>A jigsaw puzzle with tetrominoes for pieces</source>
         <translation>Een legpuzzel met tetrominovormige stukken</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="288"/>
+        <location filename="../src/window.cpp" line="285"/>
         <source>Copyright &amp;copy; 2008-%1 Graeme Gott</source>
         <translation>Copyright &amp;copy; 2008-%1 Graeme Gott</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="289"/>
+        <location filename="../src/window.cpp" line="286"/>
         <source>Released under the &lt;a href=%1&gt;GPL 3&lt;/a&gt; license</source>
         <translation>Uitgegeven onder de &lt;a href=%1&gt;GPL 3&lt;/a&gt; licentie</translation>
     </message>
@@ -552,12 +557,12 @@ De opgeslagen spellen van dit plaatje worden ook verwijderd.</translation>
 <context>
     <name>ZoomSlider</name>
     <message>
-        <location filename="../src/zoom_slider.cpp" line="38"/>
+        <location filename="../src/zoom_slider.cpp" line="40"/>
         <source>??%</source>
         <translation>??%</translation>
     </message>
     <message>
-        <location filename="../src/zoom_slider.cpp" line="63"/>
+        <location filename="../src/zoom_slider.cpp" line="65"/>
         <source>%1%</source>
         <translation>%1%</translation>
     </message>

--- a/translations/tetzle_pl.ts
+++ b/translations/tetzle_pl.ts
@@ -4,7 +4,7 @@
 <context>
     <name>AddImage</name>
     <message>
-        <location filename="../src/add_image.cpp" line="87"/>
+        <location filename="../src/add_image.cpp" line="79"/>
         <source>Open Image</source>
         <translation>Otwórz obraz</translation>
     </message>
@@ -32,22 +32,27 @@
         <translation>Cienie upuszczania</translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="77"/>
+        <location filename="../src/appearance_dialog.cpp" line="76"/>
+        <source>Success message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/appearance_dialog.cpp" line="79"/>
         <source>Colors</source>
         <translation>Kolory</translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="96"/>
+        <location filename="../src/appearance_dialog.cpp" line="98"/>
         <source>Background:</source>
         <translation>Tło:</translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="97"/>
+        <location filename="../src/appearance_dialog.cpp" line="99"/>
         <source>Shadow:</source>
         <translation>Cień:</translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="98"/>
+        <location filename="../src/appearance_dialog.cpp" line="100"/>
         <source>Highlight:</source>
         <translation>Zaznaczone:</translation>
     </message>
@@ -55,59 +60,59 @@
 <context>
     <name>Board</name>
     <message>
-        <location filename="../src/board.cpp" line="187"/>
-        <location filename="../src/board.cpp" line="293"/>
-        <location filename="../src/board.cpp" line="361"/>
+        <location filename="../src/board.cpp" line="190"/>
+        <location filename="../src/board.cpp" line="301"/>
+        <location filename="../src/board.cpp" line="369"/>
         <source>Error</source>
         <translation>Błąd</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="187"/>
-        <location filename="../src/board.cpp" line="293"/>
+        <location filename="../src/board.cpp" line="190"/>
+        <location filename="../src/board.cpp" line="301"/>
         <source>Missing image.</source>
         <translation>Brak obrazu.</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="194"/>
-        <location filename="../src/board.cpp" line="269"/>
-        <location filename="../src/main.cpp" line="167"/>
+        <location filename="../src/board.cpp" line="197"/>
+        <location filename="../src/board.cpp" line="277"/>
+        <location filename="../src/main.cpp" line="162"/>
         <source>Please Wait</source>
         <translation>Proszę czekać</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="216"/>
-        <location filename="../src/board.cpp" line="368"/>
+        <location filename="../src/board.cpp" line="219"/>
+        <location filename="../src/board.cpp" line="376"/>
         <source>Loading image...</source>
         <translation>Ładowanie obrazu...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="222"/>
+        <location filename="../src/board.cpp" line="225"/>
         <source>Generating puzzle...</source>
         <translation>Tworzenie puzzli...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="228"/>
-        <location filename="../src/board.cpp" line="242"/>
+        <location filename="../src/board.cpp" line="236"/>
+        <location filename="../src/board.cpp" line="250"/>
         <source>Creating pieces...</source>
         <translation>Tworzenie części...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="281"/>
+        <location filename="../src/board.cpp" line="289"/>
         <source>Loading puzzle...</source>
         <translation>Ładowanie puzzli...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="306"/>
+        <location filename="../src/board.cpp" line="314"/>
         <source>Unknown data format</source>
         <translation>Nieznany format danych</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="356"/>
+        <location filename="../src/board.cpp" line="364"/>
         <source>Unknown element &apos;%1&apos;</source>
         <translation>Nieznany element &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="361"/>
+        <location filename="../src/board.cpp" line="369"/>
         <source>Error parsing XML file.
 
 %1</source>
@@ -116,22 +121,22 @@
 %1</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="372"/>
+        <location filename="../src/board.cpp" line="380"/>
         <source>Loading pieces...</source>
         <translation>Ładowanie części...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="454"/>
+        <location filename="../src/board.cpp" line="462"/>
         <source>Retrieving pieces...</source>
         <translation>Pobieranie części...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="994"/>
+        <location filename="../src/board.cpp" line="1002"/>
         <source>Placing pieces...</source>
         <translation>Umieszczanie części...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="1326"/>
+        <location filename="../src/board.cpp" line="1331"/>
         <source>Success</source>
         <translation>Sukces</translation>
     </message>
@@ -175,22 +180,22 @@
 <context>
     <name>LocaleDialog</name>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="50"/>
+        <location filename="../src/locale_dialog.cpp" line="52"/>
         <source>Select application language:</source>
         <translation>Wybierz język programu:</translation>
     </message>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="53"/>
+        <location filename="../src/locale_dialog.cpp" line="55"/>
         <source>&lt;System Language&gt;</source>
         <translation>&lt;Język systemowy&gt;</translation>
     </message>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="183"/>
+        <location filename="../src/locale_dialog.cpp" line="172"/>
         <source>Note</source>
         <translation>Uwaga</translation>
     </message>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="183"/>
+        <location filename="../src/locale_dialog.cpp" line="172"/>
         <source>Please restart this application for the change in language to take effect.</source>
         <translation>Proszę ponownie uruchomić ten program, aby zastosować zmianę języka.</translation>
     </message>
@@ -198,44 +203,44 @@
 <context>
     <name>NewGameTab</name>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="105"/>
+        <location filename="../src/new_game_tab.cpp" line="106"/>
         <source>Add Image</source>
         <translation>Dodaj obraz</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="109"/>
-        <location filename="../src/new_game_tab.cpp" line="290"/>
+        <location filename="../src/new_game_tab.cpp" line="110"/>
+        <location filename="../src/new_game_tab.cpp" line="291"/>
         <source>Remove Image</source>
         <translation>Usuń obraz</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="113"/>
+        <location filename="../src/new_game_tab.cpp" line="114"/>
         <source>Image Properties</source>
         <translation>Właściwości obrazu</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="132"/>
-        <location filename="../src/new_game_tab.cpp" line="383"/>
+        <location filename="../src/new_game_tab.cpp" line="133"/>
+        <location filename="../src/new_game_tab.cpp" line="384"/>
         <source>%L1 pieces</source>
         <translation>%L1 części</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="193"/>
+        <location filename="../src/new_game_tab.cpp" line="194"/>
         <source>Copying images...</source>
         <translation>Kopiowanie obrazów...</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="193"/>
+        <location filename="../src/new_game_tab.cpp" line="194"/>
         <source>Cancel</source>
         <translation>Anuluj</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="286"/>
+        <location filename="../src/new_game_tab.cpp" line="287"/>
         <source>Remove selected image?</source>
         <translation>Usunąć wybrany obraz?</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="288"/>
+        <location filename="../src/new_game_tab.cpp" line="289"/>
         <source>Remove selected image?
 
 There are saved games using this image that will also be removed.</source>
@@ -244,7 +249,7 @@ There are saved games using this image that will also be removed.</source>
 Istniejące zapisane gry, które używają tego obrazu, zostaną również usunięte.</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="493"/>
+        <location filename="../src/new_game_tab.cpp" line="494"/>
         <source>Untitled</source>
         <translation>Bez tytułu</translation>
     </message>
@@ -280,7 +285,7 @@ Istniejące zapisane gry, które używają tego obrazu, zostaną również usuni
 <context>
     <name>Overview</name>
     <message>
-        <location filename="../src/overview.cpp" line="38"/>
+        <location filename="../src/overview.cpp" line="39"/>
         <source>Overview</source>
         <translation>Przegląd</translation>
     </message>
@@ -336,215 +341,215 @@ Istniejące zapisane gry, które używają tego obrazu, zostaną również usuni
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/main.cpp" line="168"/>
-        <location filename="../src/window.cpp" line="50"/>
-        <location filename="../src/window.cpp" line="286"/>
+        <location filename="../src/main.cpp" line="56"/>
+        <location filename="../src/main.cpp" line="163"/>
+        <location filename="../src/window.cpp" line="283"/>
         <source>Tetzle</source>
         <translation>Tetzle</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="80"/>
+        <location filename="../src/window.cpp" line="79"/>
         <source>&amp;Game</source>
         <translation>&amp;Gra</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="84"/>
+        <location filename="../src/window.cpp" line="83"/>
         <source>&amp;Retrieve Pieces</source>
         <translation>&amp;Pobierz części</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="84"/>
+        <location filename="../src/window.cpp" line="83"/>
         <source>Ctrl+R</source>
         <translation>Ctrl+R</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="88"/>
+        <location filename="../src/window.cpp" line="87"/>
         <source>&amp;Quit</source>
         <translation>&amp;Zakończ</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="81"/>
+        <location filename="../src/window.cpp" line="80"/>
         <source>&amp;Choose...</source>
         <translation>W&amp;ybierz...</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="91"/>
+        <location filename="../src/window.cpp" line="90"/>
         <source>&amp;View</source>
         <translation>&amp;Widok</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="92"/>
+        <location filename="../src/window.cpp" line="91"/>
         <source>Zoom &amp;In</source>
         <translation>&amp;Przybliż</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="92"/>
+        <location filename="../src/window.cpp" line="91"/>
         <source>+</source>
         <translation>+</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="95"/>
+        <location filename="../src/window.cpp" line="94"/>
         <source>Zoom &amp;Out</source>
         <translation>&amp;Oddal</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="95"/>
+        <location filename="../src/window.cpp" line="94"/>
         <source>-</source>
         <translation>-</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="98"/>
+        <location filename="../src/window.cpp" line="97"/>
         <source>Best &amp;Fit</source>
         <translation>&amp;Najlepsze dopasowanie</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="101"/>
+        <location filename="../src/window.cpp" line="100"/>
         <source>Show O&amp;verview</source>
         <translation>Pokaż p&amp;odgląd</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="101"/>
+        <location filename="../src/window.cpp" line="100"/>
         <source>Tab</source>
         <translation>Tab</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="107"/>
+        <location filename="../src/window.cpp" line="106"/>
         <source>F&amp;ullscreen</source>
         <translation>Pełny &amp;ekran</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="111"/>
+        <location filename="../src/window.cpp" line="110"/>
         <source>F11</source>
         <translation>F11</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="113"/>
+        <location filename="../src/window.cpp" line="112"/>
         <source>Ctrl+F</source>
         <translation>Ctrl+F</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="116"/>
+        <location filename="../src/window.cpp" line="115"/>
         <source>&amp;Settings</source>
         <translation>&amp;Ustawienia</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="117"/>
+        <location filename="../src/window.cpp" line="116"/>
         <source>&amp;Appearance...</source>
         <translation>Wy&amp;gląd...</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="118"/>
+        <location filename="../src/window.cpp" line="117"/>
         <source>&amp;Language...</source>
         <translation>&amp;Język...</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="120"/>
+        <location filename="../src/window.cpp" line="119"/>
         <source>&amp;Help</source>
         <translation>&amp;Pomoc</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="121"/>
+        <location filename="../src/window.cpp" line="120"/>
         <source>&amp;Controls</source>
         <translation>&amp;Sterowanie</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="123"/>
+        <location filename="../src/window.cpp" line="122"/>
         <source>&amp;About</source>
         <translation>&amp;O</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="125"/>
+        <location filename="../src/window.cpp" line="124"/>
         <source>About &amp;Qt</source>
         <translation>O &amp;Qt</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="252"/>
+        <location filename="../src/window.cpp" line="249"/>
         <source>Controls</source>
         <translation>Sterowanie</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="259"/>
+        <location filename="../src/window.cpp" line="256"/>
         <source>&lt;b&gt;Pick Up Pieces:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Podnoszenie części:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="260"/>
-        <location filename="../src/window.cpp" line="262"/>
+        <location filename="../src/window.cpp" line="257"/>
+        <location filename="../src/window.cpp" line="259"/>
         <source>Left Click or Space</source>
         <translation>Lewy przycisk myszy lub spacja</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="261"/>
+        <location filename="../src/window.cpp" line="258"/>
         <source>&lt;b&gt;Drop Pieces:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Upuszczanie części:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="263"/>
+        <location filename="../src/window.cpp" line="260"/>
         <source>&lt;b&gt;Select Pieces:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Wybór części:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="264"/>
+        <location filename="../src/window.cpp" line="261"/>
         <source>Left Drag</source>
         <translation>Przeciągając lewym przyciskiem myszy</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="265"/>
+        <location filename="../src/window.cpp" line="262"/>
         <source>&lt;b&gt;Rotate Pieces:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Obróć części:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="266"/>
+        <location filename="../src/window.cpp" line="263"/>
         <source>Right Click, Control + Left Click, or R</source>
         <translation>Prawy przycisk myszy, Control + Lewy przycisk myszy lub R</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="267"/>
+        <location filename="../src/window.cpp" line="264"/>
         <source>&lt;b&gt;Drag Puzzle:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Przeciąganie puzzli:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="268"/>
+        <location filename="../src/window.cpp" line="265"/>
         <source>Middle Click, Shift + Left Click, or Arrows</source>
         <translation>Środkowy przycisk myszy, Shift + Lewy przycisk myszy, lub strzałki</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="269"/>
+        <location filename="../src/window.cpp" line="266"/>
         <source>&lt;b&gt;Zoom Puzzle:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Powiększanie puzzli:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="270"/>
+        <location filename="../src/window.cpp" line="267"/>
         <source>Scrollwheel or +/-</source>
         <translation>Kółko myszy lub +/-</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="271"/>
+        <location filename="../src/window.cpp" line="268"/>
         <source>&lt;b&gt;Move Cursor:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Przesuwanie kursora:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="272"/>
+        <location filename="../src/window.cpp" line="269"/>
         <source>Move mouse or W,A,D,S</source>
         <translation>Przesuń myszą lub W,A,D,S</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="285"/>
+        <location filename="../src/window.cpp" line="282"/>
         <source>About Tetzle</source>
         <translation>O Tetzle</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="287"/>
+        <location filename="../src/window.cpp" line="284"/>
         <source>A jigsaw puzzle with tetrominoes for pieces</source>
         <translation>Gra puzzle z części o kształcie tetromina</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="288"/>
+        <location filename="../src/window.cpp" line="285"/>
         <source>Copyright &amp;copy; 2008-%1 Graeme Gott</source>
         <translation>Prawo autorskie &amp;copy; 2008-%1 Graeme Gott</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="289"/>
+        <location filename="../src/window.cpp" line="286"/>
         <source>Released under the &lt;a href=%1&gt;GPL 3&lt;/a&gt; license</source>
         <translation>Wydano na licencji &lt;a href=%1&gt;GPL 3&lt;/a&gt;</translation>
     </message>
@@ -552,12 +557,12 @@ Istniejące zapisane gry, które używają tego obrazu, zostaną również usuni
 <context>
     <name>ZoomSlider</name>
     <message>
-        <location filename="../src/zoom_slider.cpp" line="38"/>
+        <location filename="../src/zoom_slider.cpp" line="40"/>
         <source>??%</source>
         <translation>??%</translation>
     </message>
     <message>
-        <location filename="../src/zoom_slider.cpp" line="63"/>
+        <location filename="../src/zoom_slider.cpp" line="65"/>
         <source>%1%</source>
         <translation>%1%</translation>
     </message>

--- a/translations/tetzle_pt_BR.ts
+++ b/translations/tetzle_pt_BR.ts
@@ -4,7 +4,7 @@
 <context>
     <name>AddImage</name>
     <message>
-        <location filename="../src/add_image.cpp" line="87"/>
+        <location filename="../src/add_image.cpp" line="79"/>
         <source>Open Image</source>
         <translation>Abrir imagem</translation>
     </message>
@@ -32,22 +32,27 @@
         <translation>Sombras externas</translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="77"/>
+        <location filename="../src/appearance_dialog.cpp" line="76"/>
+        <source>Success message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/appearance_dialog.cpp" line="79"/>
         <source>Colors</source>
         <translation>Cores</translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="96"/>
+        <location filename="../src/appearance_dialog.cpp" line="98"/>
         <source>Background:</source>
         <translation>Fundo:</translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="97"/>
+        <location filename="../src/appearance_dialog.cpp" line="99"/>
         <source>Shadow:</source>
         <translation>Sombra:</translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="98"/>
+        <location filename="../src/appearance_dialog.cpp" line="100"/>
         <source>Highlight:</source>
         <translation>Realce:</translation>
     </message>
@@ -55,59 +60,59 @@
 <context>
     <name>Board</name>
     <message>
-        <location filename="../src/board.cpp" line="187"/>
-        <location filename="../src/board.cpp" line="293"/>
-        <location filename="../src/board.cpp" line="361"/>
+        <location filename="../src/board.cpp" line="190"/>
+        <location filename="../src/board.cpp" line="301"/>
+        <location filename="../src/board.cpp" line="369"/>
         <source>Error</source>
         <translation>Erro</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="187"/>
-        <location filename="../src/board.cpp" line="293"/>
+        <location filename="../src/board.cpp" line="190"/>
+        <location filename="../src/board.cpp" line="301"/>
         <source>Missing image.</source>
         <translation>Faltando imagem.</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="194"/>
-        <location filename="../src/board.cpp" line="269"/>
-        <location filename="../src/main.cpp" line="167"/>
+        <location filename="../src/board.cpp" line="197"/>
+        <location filename="../src/board.cpp" line="277"/>
+        <location filename="../src/main.cpp" line="162"/>
         <source>Please Wait</source>
         <translation>Por favor aguarde</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="216"/>
-        <location filename="../src/board.cpp" line="368"/>
+        <location filename="../src/board.cpp" line="219"/>
+        <location filename="../src/board.cpp" line="376"/>
         <source>Loading image...</source>
         <translation>Carregando imagem...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="222"/>
+        <location filename="../src/board.cpp" line="225"/>
         <source>Generating puzzle...</source>
         <translation>Gerando quebra-cabeças...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="228"/>
-        <location filename="../src/board.cpp" line="242"/>
+        <location filename="../src/board.cpp" line="236"/>
+        <location filename="../src/board.cpp" line="250"/>
         <source>Creating pieces...</source>
         <translation>Criando peças...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="281"/>
+        <location filename="../src/board.cpp" line="289"/>
         <source>Loading puzzle...</source>
         <translation>Carregando quebra-cabeças...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="306"/>
+        <location filename="../src/board.cpp" line="314"/>
         <source>Unknown data format</source>
         <translation>Formato de dados desconhecido</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="356"/>
+        <location filename="../src/board.cpp" line="364"/>
         <source>Unknown element &apos;%1&apos;</source>
         <translation>Elemento desconhecido &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="361"/>
+        <location filename="../src/board.cpp" line="369"/>
         <source>Error parsing XML file.
 
 %1</source>
@@ -116,22 +121,22 @@
 %1</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="372"/>
+        <location filename="../src/board.cpp" line="380"/>
         <source>Loading pieces...</source>
         <translation>Carregando peças...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="454"/>
+        <location filename="../src/board.cpp" line="462"/>
         <source>Retrieving pieces...</source>
         <translation>Recuperando peças...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="994"/>
+        <location filename="../src/board.cpp" line="1002"/>
         <source>Placing pieces...</source>
         <translation>Posicionando peças...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="1326"/>
+        <location filename="../src/board.cpp" line="1331"/>
         <source>Success</source>
         <translation>Sucesso</translation>
     </message>
@@ -175,22 +180,22 @@
 <context>
     <name>LocaleDialog</name>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="50"/>
+        <location filename="../src/locale_dialog.cpp" line="52"/>
         <source>Select application language:</source>
         <translation>Selecione o idioma do jogo:</translation>
     </message>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="53"/>
+        <location filename="../src/locale_dialog.cpp" line="55"/>
         <source>&lt;System Language&gt;</source>
         <translation>&lt;Idioma do sistema&gt;</translation>
     </message>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="183"/>
+        <location filename="../src/locale_dialog.cpp" line="172"/>
         <source>Note</source>
         <translation>Nota</translation>
     </message>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="183"/>
+        <location filename="../src/locale_dialog.cpp" line="172"/>
         <source>Please restart this application for the change in language to take effect.</source>
         <translation>Por favor reinicie o jogo para que a alteração do idioma faça efeito.</translation>
     </message>
@@ -198,44 +203,44 @@
 <context>
     <name>NewGameTab</name>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="105"/>
+        <location filename="../src/new_game_tab.cpp" line="106"/>
         <source>Add Image</source>
         <translation>Adicionar imagem</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="109"/>
-        <location filename="../src/new_game_tab.cpp" line="290"/>
+        <location filename="../src/new_game_tab.cpp" line="110"/>
+        <location filename="../src/new_game_tab.cpp" line="291"/>
         <source>Remove Image</source>
         <translation>Remover imagem</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="113"/>
+        <location filename="../src/new_game_tab.cpp" line="114"/>
         <source>Image Properties</source>
         <translation>Propriedades da imagem</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="132"/>
-        <location filename="../src/new_game_tab.cpp" line="383"/>
+        <location filename="../src/new_game_tab.cpp" line="133"/>
+        <location filename="../src/new_game_tab.cpp" line="384"/>
         <source>%L1 pieces</source>
         <translation>%L1 peças</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="193"/>
+        <location filename="../src/new_game_tab.cpp" line="194"/>
         <source>Copying images...</source>
         <translation>Copiando imagens..</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="193"/>
+        <location filename="../src/new_game_tab.cpp" line="194"/>
         <source>Cancel</source>
         <translation>Cacelar</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="286"/>
+        <location filename="../src/new_game_tab.cpp" line="287"/>
         <source>Remove selected image?</source>
         <translation>Remover imagem selecionada?</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="288"/>
+        <location filename="../src/new_game_tab.cpp" line="289"/>
         <source>Remove selected image?
 
 There are saved games using this image that will also be removed.</source>
@@ -244,7 +249,7 @@ There are saved games using this image that will also be removed.</source>
 Os jogos salvos usando esta imagem também serão removidos.</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="493"/>
+        <location filename="../src/new_game_tab.cpp" line="494"/>
         <source>Untitled</source>
         <translation>Sem título</translation>
     </message>
@@ -280,7 +285,7 @@ Os jogos salvos usando esta imagem também serão removidos.</translation>
 <context>
     <name>Overview</name>
     <message>
-        <location filename="../src/overview.cpp" line="38"/>
+        <location filename="../src/overview.cpp" line="39"/>
         <source>Overview</source>
         <translation>Visão geral</translation>
     </message>
@@ -336,215 +341,215 @@ Os jogos salvos usando esta imagem também serão removidos.</translation>
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/main.cpp" line="168"/>
-        <location filename="../src/window.cpp" line="50"/>
-        <location filename="../src/window.cpp" line="286"/>
+        <location filename="../src/main.cpp" line="56"/>
+        <location filename="../src/main.cpp" line="163"/>
+        <location filename="../src/window.cpp" line="283"/>
         <source>Tetzle</source>
         <translation>Tetzle</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="80"/>
+        <location filename="../src/window.cpp" line="79"/>
         <source>&amp;Game</source>
         <translation>&amp;Jogo</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="84"/>
+        <location filename="../src/window.cpp" line="83"/>
         <source>&amp;Retrieve Pieces</source>
         <translation>&amp;Recuperar peças</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="84"/>
+        <location filename="../src/window.cpp" line="83"/>
         <source>Ctrl+R</source>
         <translation>Ctrl+R</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="88"/>
+        <location filename="../src/window.cpp" line="87"/>
         <source>&amp;Quit</source>
         <translation>Sai&amp;r</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="81"/>
+        <location filename="../src/window.cpp" line="80"/>
         <source>&amp;Choose...</source>
         <translation>&amp;Escolher...</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="91"/>
+        <location filename="../src/window.cpp" line="90"/>
         <source>&amp;View</source>
         <translation>&amp;Visualizar</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="92"/>
+        <location filename="../src/window.cpp" line="91"/>
         <source>Zoom &amp;In</source>
         <translation>&amp;Aumentar Zoom</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="92"/>
+        <location filename="../src/window.cpp" line="91"/>
         <source>+</source>
         <translation>+</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="95"/>
+        <location filename="../src/window.cpp" line="94"/>
         <source>Zoom &amp;Out</source>
         <translation>&amp;Diminuir Zoom</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="95"/>
+        <location filename="../src/window.cpp" line="94"/>
         <source>-</source>
         <translation>-</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="98"/>
+        <location filename="../src/window.cpp" line="97"/>
         <source>Best &amp;Fit</source>
         <translation>Ajustar à &amp;tela</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="101"/>
+        <location filename="../src/window.cpp" line="100"/>
         <source>Show O&amp;verview</source>
         <translation>Exibir &amp;visão geral</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="101"/>
+        <location filename="../src/window.cpp" line="100"/>
         <source>Tab</source>
         <translation>Tab</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="107"/>
+        <location filename="../src/window.cpp" line="106"/>
         <source>F&amp;ullscreen</source>
         <translation>Tela &amp;cheia</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="111"/>
+        <location filename="../src/window.cpp" line="110"/>
         <source>F11</source>
         <translation>F11</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="113"/>
+        <location filename="../src/window.cpp" line="112"/>
         <source>Ctrl+F</source>
         <translation>Ctrl+F</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="116"/>
+        <location filename="../src/window.cpp" line="115"/>
         <source>&amp;Settings</source>
         <translation>&amp;Configurações</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="117"/>
+        <location filename="../src/window.cpp" line="116"/>
         <source>&amp;Appearance...</source>
         <translation>&amp;Aparência...</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="118"/>
+        <location filename="../src/window.cpp" line="117"/>
         <source>&amp;Language...</source>
         <translation>&amp;Idioma...</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="120"/>
+        <location filename="../src/window.cpp" line="119"/>
         <source>&amp;Help</source>
         <translation>A&amp;juda</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="121"/>
+        <location filename="../src/window.cpp" line="120"/>
         <source>&amp;Controls</source>
         <translation>&amp;Controles</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="123"/>
+        <location filename="../src/window.cpp" line="122"/>
         <source>&amp;About</source>
         <translation>&amp;Sobre</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="125"/>
+        <location filename="../src/window.cpp" line="124"/>
         <source>About &amp;Qt</source>
         <translation>Sobre o &amp;Qt</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="252"/>
+        <location filename="../src/window.cpp" line="249"/>
         <source>Controls</source>
         <translation>Controles</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="259"/>
+        <location filename="../src/window.cpp" line="256"/>
         <source>&lt;b&gt;Pick Up Pieces:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Pegar peças:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="260"/>
-        <location filename="../src/window.cpp" line="262"/>
+        <location filename="../src/window.cpp" line="257"/>
+        <location filename="../src/window.cpp" line="259"/>
         <source>Left Click or Space</source>
         <translation>Clique esquerdo ou espaço</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="261"/>
+        <location filename="../src/window.cpp" line="258"/>
         <source>&lt;b&gt;Drop Pieces:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Deixar peças:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="263"/>
+        <location filename="../src/window.cpp" line="260"/>
         <source>&lt;b&gt;Select Pieces:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Selecionar peças:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="264"/>
+        <location filename="../src/window.cpp" line="261"/>
         <source>Left Drag</source>
         <translation>Arrastar com botão esquerdo</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="265"/>
+        <location filename="../src/window.cpp" line="262"/>
         <source>&lt;b&gt;Rotate Pieces:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Girar peças:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="266"/>
+        <location filename="../src/window.cpp" line="263"/>
         <source>Right Click, Control + Left Click, or R</source>
         <translation>Clique direito, Control + clique esquerdo, ou R</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="267"/>
+        <location filename="../src/window.cpp" line="264"/>
         <source>&lt;b&gt;Drag Puzzle:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Arrastar quebra-cabeças:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="268"/>
+        <location filename="../src/window.cpp" line="265"/>
         <source>Middle Click, Shift + Left Click, or Arrows</source>
         <translation>Clique no meio, Shift + Clique esquerdo, ou setas direcionais</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="269"/>
+        <location filename="../src/window.cpp" line="266"/>
         <source>&lt;b&gt;Zoom Puzzle:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Aumentar/diminuir zoom:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="270"/>
+        <location filename="../src/window.cpp" line="267"/>
         <source>Scrollwheel or +/-</source>
         <translation>Roda do mouse ou +/-</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="271"/>
+        <location filename="../src/window.cpp" line="268"/>
         <source>&lt;b&gt;Move Cursor:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Mover cursor:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="272"/>
+        <location filename="../src/window.cpp" line="269"/>
         <source>Move mouse or W,A,D,S</source>
         <translation>Mova o mouse ou W, A, S, D</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="285"/>
+        <location filename="../src/window.cpp" line="282"/>
         <source>About Tetzle</source>
         <translation>Sobre o Teztle</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="287"/>
+        <location filename="../src/window.cpp" line="284"/>
         <source>A jigsaw puzzle with tetrominoes for pieces</source>
         <translation>Quebra-cabeças com peças em formato de tetris</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="288"/>
+        <location filename="../src/window.cpp" line="285"/>
         <source>Copyright &amp;copy; 2008-%1 Graeme Gott</source>
         <translation>Copyright &amp;copy; 2008-%1 Graeme Gott</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="289"/>
+        <location filename="../src/window.cpp" line="286"/>
         <source>Released under the &lt;a href=%1&gt;GPL 3&lt;/a&gt; license</source>
         <translation>Licenciado sob os termos da &lt;a href=%1&gt;GPL 3&lt;/a&gt;</translation>
     </message>
@@ -552,12 +557,12 @@ Os jogos salvos usando esta imagem também serão removidos.</translation>
 <context>
     <name>ZoomSlider</name>
     <message>
-        <location filename="../src/zoom_slider.cpp" line="38"/>
+        <location filename="../src/zoom_slider.cpp" line="40"/>
         <source>??%</source>
         <translation>??%</translation>
     </message>
     <message>
-        <location filename="../src/zoom_slider.cpp" line="63"/>
+        <location filename="../src/zoom_slider.cpp" line="65"/>
         <source>%1%</source>
         <translation>%1%</translation>
     </message>

--- a/translations/tetzle_ro.ts
+++ b/translations/tetzle_ro.ts
@@ -4,7 +4,7 @@
 <context>
     <name>AddImage</name>
     <message>
-        <location filename="../src/add_image.cpp" line="87"/>
+        <location filename="../src/add_image.cpp" line="79"/>
         <source>Open Image</source>
         <translation>Deschide imagine</translation>
     </message>
@@ -32,22 +32,27 @@
         <translation>Umbrire</translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="77"/>
+        <location filename="../src/appearance_dialog.cpp" line="76"/>
+        <source>Success message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/appearance_dialog.cpp" line="79"/>
         <source>Colors</source>
         <translation>Culori</translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="96"/>
+        <location filename="../src/appearance_dialog.cpp" line="98"/>
         <source>Background:</source>
         <translation>Fundal:</translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="97"/>
+        <location filename="../src/appearance_dialog.cpp" line="99"/>
         <source>Shadow:</source>
         <translation>Umbre:</translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="98"/>
+        <location filename="../src/appearance_dialog.cpp" line="100"/>
         <source>Highlight:</source>
         <translation>Evidenţiere:</translation>
     </message>
@@ -55,59 +60,59 @@
 <context>
     <name>Board</name>
     <message>
-        <location filename="../src/board.cpp" line="187"/>
-        <location filename="../src/board.cpp" line="293"/>
-        <location filename="../src/board.cpp" line="361"/>
+        <location filename="../src/board.cpp" line="190"/>
+        <location filename="../src/board.cpp" line="301"/>
+        <location filename="../src/board.cpp" line="369"/>
         <source>Error</source>
         <translation>Eroare</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="187"/>
-        <location filename="../src/board.cpp" line="293"/>
+        <location filename="../src/board.cpp" line="190"/>
+        <location filename="../src/board.cpp" line="301"/>
         <source>Missing image.</source>
         <translation>Lipseşte imagine.</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="194"/>
-        <location filename="../src/board.cpp" line="269"/>
-        <location filename="../src/main.cpp" line="167"/>
+        <location filename="../src/board.cpp" line="197"/>
+        <location filename="../src/board.cpp" line="277"/>
+        <location filename="../src/main.cpp" line="162"/>
         <source>Please Wait</source>
         <translation>Vă rugăm aşteptaţi</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="216"/>
-        <location filename="../src/board.cpp" line="368"/>
+        <location filename="../src/board.cpp" line="219"/>
+        <location filename="../src/board.cpp" line="376"/>
         <source>Loading image...</source>
         <translation>Încărcare imagine...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="222"/>
+        <location filename="../src/board.cpp" line="225"/>
         <source>Generating puzzle...</source>
         <translation>Generare puzzle...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="228"/>
-        <location filename="../src/board.cpp" line="242"/>
+        <location filename="../src/board.cpp" line="236"/>
+        <location filename="../src/board.cpp" line="250"/>
         <source>Creating pieces...</source>
         <translation>Creare piese...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="281"/>
+        <location filename="../src/board.cpp" line="289"/>
         <source>Loading puzzle...</source>
         <translation>Încărcare puzzle...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="306"/>
+        <location filename="../src/board.cpp" line="314"/>
         <source>Unknown data format</source>
         <translation>Format date necunoscut</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="356"/>
+        <location filename="../src/board.cpp" line="364"/>
         <source>Unknown element &apos;%1&apos;</source>
         <translation>Element necunoscut &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="361"/>
+        <location filename="../src/board.cpp" line="369"/>
         <source>Error parsing XML file.
 
 %1</source>
@@ -116,22 +121,22 @@
 %1</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="372"/>
+        <location filename="../src/board.cpp" line="380"/>
         <source>Loading pieces...</source>
         <translation>Încărcare piese...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="454"/>
+        <location filename="../src/board.cpp" line="462"/>
         <source>Retrieving pieces...</source>
         <translation>Preluare piese...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="994"/>
+        <location filename="../src/board.cpp" line="1002"/>
         <source>Placing pieces...</source>
         <translation>Plasare  piese...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="1326"/>
+        <location filename="../src/board.cpp" line="1331"/>
         <source>Success</source>
         <translation>Succes</translation>
     </message>
@@ -175,22 +180,22 @@
 <context>
     <name>LocaleDialog</name>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="50"/>
+        <location filename="../src/locale_dialog.cpp" line="52"/>
         <source>Select application language:</source>
         <translation>Selectaţi limba aplicaţiei:</translation>
     </message>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="53"/>
+        <location filename="../src/locale_dialog.cpp" line="55"/>
         <source>&lt;System Language&gt;</source>
         <translation>&lt;Limbaj Sistem&gt;</translation>
     </message>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="183"/>
+        <location filename="../src/locale_dialog.cpp" line="172"/>
         <source>Note</source>
         <translation>Notă</translation>
     </message>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="183"/>
+        <location filename="../src/locale_dialog.cpp" line="172"/>
         <source>Please restart this application for the change in language to take effect.</source>
         <translation>Vă rugăm reporniţi această aplicaţie pentru ca schimbarea limbii să aibă efect.</translation>
     </message>
@@ -198,44 +203,44 @@
 <context>
     <name>NewGameTab</name>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="105"/>
+        <location filename="../src/new_game_tab.cpp" line="106"/>
         <source>Add Image</source>
         <translation>Adăugare imagine</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="109"/>
-        <location filename="../src/new_game_tab.cpp" line="290"/>
+        <location filename="../src/new_game_tab.cpp" line="110"/>
+        <location filename="../src/new_game_tab.cpp" line="291"/>
         <source>Remove Image</source>
         <translation>Eliminare imagine</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="113"/>
+        <location filename="../src/new_game_tab.cpp" line="114"/>
         <source>Image Properties</source>
         <translation>Proprietăţi imagine</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="132"/>
-        <location filename="../src/new_game_tab.cpp" line="383"/>
+        <location filename="../src/new_game_tab.cpp" line="133"/>
+        <location filename="../src/new_game_tab.cpp" line="384"/>
         <source>%L1 pieces</source>
         <translation>%L1 piese</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="193"/>
+        <location filename="../src/new_game_tab.cpp" line="194"/>
         <source>Copying images...</source>
         <translation>Copiere imagini...</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="193"/>
+        <location filename="../src/new_game_tab.cpp" line="194"/>
         <source>Cancel</source>
         <translation>Anulare</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="286"/>
+        <location filename="../src/new_game_tab.cpp" line="287"/>
         <source>Remove selected image?</source>
         <translation>Eliminaţi imaginea selectată?</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="288"/>
+        <location filename="../src/new_game_tab.cpp" line="289"/>
         <source>Remove selected image?
 
 There are saved games using this image that will also be removed.</source>
@@ -244,7 +249,7 @@ There are saved games using this image that will also be removed.</source>
 Există jocuri salvate care folosesc această imagine, care vor fi, de asemenea, eliminate.</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="493"/>
+        <location filename="../src/new_game_tab.cpp" line="494"/>
         <source>Untitled</source>
         <translation>FărăTitlu</translation>
     </message>
@@ -280,7 +285,7 @@ Există jocuri salvate care folosesc această imagine, care vor fi, de asemenea,
 <context>
     <name>Overview</name>
     <message>
-        <location filename="../src/overview.cpp" line="38"/>
+        <location filename="../src/overview.cpp" line="39"/>
         <source>Overview</source>
         <translation>Imagine de ansamblu</translation>
     </message>
@@ -336,215 +341,215 @@ Există jocuri salvate care folosesc această imagine, care vor fi, de asemenea,
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/main.cpp" line="168"/>
-        <location filename="../src/window.cpp" line="50"/>
-        <location filename="../src/window.cpp" line="286"/>
+        <location filename="../src/main.cpp" line="56"/>
+        <location filename="../src/main.cpp" line="163"/>
+        <location filename="../src/window.cpp" line="283"/>
         <source>Tetzle</source>
         <translation>Tetzle</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="80"/>
+        <location filename="../src/window.cpp" line="79"/>
         <source>&amp;Game</source>
         <translation>&amp;Joc</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="84"/>
+        <location filename="../src/window.cpp" line="83"/>
         <source>&amp;Retrieve Pieces</source>
         <translation>P&amp;reluare piese</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="84"/>
+        <location filename="../src/window.cpp" line="83"/>
         <source>Ctrl+R</source>
         <translation>Ctrl+R</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="88"/>
+        <location filename="../src/window.cpp" line="87"/>
         <source>&amp;Quit</source>
         <translation>&amp;Ieşire</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="81"/>
+        <location filename="../src/window.cpp" line="80"/>
         <source>&amp;Choose...</source>
         <translation>Alegeţi...</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="91"/>
+        <location filename="../src/window.cpp" line="90"/>
         <source>&amp;View</source>
         <translation>&amp;Vizualizare</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="92"/>
+        <location filename="../src/window.cpp" line="91"/>
         <source>Zoom &amp;In</source>
         <translation>&amp;Mărire</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="92"/>
+        <location filename="../src/window.cpp" line="91"/>
         <source>+</source>
         <translation>+</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="95"/>
+        <location filename="../src/window.cpp" line="94"/>
         <source>Zoom &amp;Out</source>
         <translation>M&amp;icşorare</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="95"/>
+        <location filename="../src/window.cpp" line="94"/>
         <source>-</source>
         <translation>-</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="98"/>
+        <location filename="../src/window.cpp" line="97"/>
         <source>Best &amp;Fit</source>
         <translation>Cel mai potrivit</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="101"/>
+        <location filename="../src/window.cpp" line="100"/>
         <source>Show O&amp;verview</source>
         <translation>Arată imagine de ansamblu</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="101"/>
+        <location filename="../src/window.cpp" line="100"/>
         <source>Tab</source>
         <translation>Tab</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="107"/>
+        <location filename="../src/window.cpp" line="106"/>
         <source>F&amp;ullscreen</source>
         <translation>&amp;Tot ecranul</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="111"/>
+        <location filename="../src/window.cpp" line="110"/>
         <source>F11</source>
         <translation>F11</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="113"/>
+        <location filename="../src/window.cpp" line="112"/>
         <source>Ctrl+F</source>
         <translation>Ctrl+F</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="116"/>
+        <location filename="../src/window.cpp" line="115"/>
         <source>&amp;Settings</source>
         <translation>&amp;Setări</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="117"/>
+        <location filename="../src/window.cpp" line="116"/>
         <source>&amp;Appearance...</source>
         <translation>&amp;Aspect...</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="118"/>
+        <location filename="../src/window.cpp" line="117"/>
         <source>&amp;Language...</source>
         <translation>&amp;Limbă...</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="120"/>
+        <location filename="../src/window.cpp" line="119"/>
         <source>&amp;Help</source>
         <translation>&amp;Ajutor</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="121"/>
+        <location filename="../src/window.cpp" line="120"/>
         <source>&amp;Controls</source>
         <translation>&amp;Controale</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="123"/>
+        <location filename="../src/window.cpp" line="122"/>
         <source>&amp;About</source>
         <translation>&amp;Despre</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="125"/>
+        <location filename="../src/window.cpp" line="124"/>
         <source>About &amp;Qt</source>
         <translation>Despre &amp;Qt</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="252"/>
+        <location filename="../src/window.cpp" line="249"/>
         <source>Controls</source>
         <translation>Controale</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="259"/>
+        <location filename="../src/window.cpp" line="256"/>
         <source>&lt;b&gt;Pick Up Pieces:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Piese ridicate:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="260"/>
-        <location filename="../src/window.cpp" line="262"/>
+        <location filename="../src/window.cpp" line="257"/>
+        <location filename="../src/window.cpp" line="259"/>
         <source>Left Click or Space</source>
         <translation>Clic stînga sau spaţiu</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="261"/>
+        <location filename="../src/window.cpp" line="258"/>
         <source>&lt;b&gt;Drop Pieces:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Piese coborîte:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="263"/>
+        <location filename="../src/window.cpp" line="260"/>
         <source>&lt;b&gt;Select Pieces:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Selectare piese:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="264"/>
+        <location filename="../src/window.cpp" line="261"/>
         <source>Left Drag</source>
         <translation>Glisare stînga</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="265"/>
+        <location filename="../src/window.cpp" line="262"/>
         <source>&lt;b&gt;Rotate Pieces:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Rotire piese:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="266"/>
+        <location filename="../src/window.cpp" line="263"/>
         <source>Right Click, Control + Left Click, or R</source>
         <translation>Clic dreapta, Control + Clic stînga, sau R</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="267"/>
+        <location filename="../src/window.cpp" line="264"/>
         <source>&lt;b&gt;Drag Puzzle:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Glisare puzzle:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="268"/>
+        <location filename="../src/window.cpp" line="265"/>
         <source>Middle Click, Shift + Left Click, or Arrows</source>
         <translation>Clic mijloc, Shift + Clic stînga, sau Săgeţi</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="269"/>
+        <location filename="../src/window.cpp" line="266"/>
         <source>&lt;b&gt;Zoom Puzzle:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Mărire puzzle:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="270"/>
+        <location filename="../src/window.cpp" line="267"/>
         <source>Scrollwheel or +/-</source>
         <translation>Rotiţa de derulare or +/-</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="271"/>
+        <location filename="../src/window.cpp" line="268"/>
         <source>&lt;b&gt;Move Cursor:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Mutare cursor:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="272"/>
+        <location filename="../src/window.cpp" line="269"/>
         <source>Move mouse or W,A,D,S</source>
         <translation>Mutare mouse sau W,A,D,S</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="285"/>
+        <location filename="../src/window.cpp" line="282"/>
         <source>About Tetzle</source>
         <translation>Despre Tetzle</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="287"/>
+        <location filename="../src/window.cpp" line="284"/>
         <source>A jigsaw puzzle with tetrominoes for pieces</source>
         <translation>Un puzzle cu tetromino-uri pentru piese</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="288"/>
+        <location filename="../src/window.cpp" line="285"/>
         <source>Copyright &amp;copy; 2008-%1 Graeme Gott</source>
         <translation>Toate drepturile rezervate &amp;copy; 2008-%1 Graeme Gott</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="289"/>
+        <location filename="../src/window.cpp" line="286"/>
         <source>Released under the &lt;a href=%1&gt;GPL 3&lt;/a&gt; license</source>
         <translation>Lansat sub licenţă &lt;a href=%1&gt;GPL 3&lt;/a&gt;</translation>
     </message>
@@ -552,12 +557,12 @@ Există jocuri salvate care folosesc această imagine, care vor fi, de asemenea,
 <context>
     <name>ZoomSlider</name>
     <message>
-        <location filename="../src/zoom_slider.cpp" line="38"/>
+        <location filename="../src/zoom_slider.cpp" line="40"/>
         <source>??%</source>
         <translation>??%</translation>
     </message>
     <message>
-        <location filename="../src/zoom_slider.cpp" line="63"/>
+        <location filename="../src/zoom_slider.cpp" line="65"/>
         <source>%1%</source>
         <translation>%1%</translation>
     </message>

--- a/translations/tetzle_ru.ts
+++ b/translations/tetzle_ru.ts
@@ -4,7 +4,7 @@
 <context>
     <name>AddImage</name>
     <message>
-        <location filename="../src/add_image.cpp" line="87"/>
+        <location filename="../src/add_image.cpp" line="79"/>
         <source>Open Image</source>
         <translation>Открыть изображение</translation>
     </message>
@@ -32,22 +32,27 @@
         <translation>Убрать тени</translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="77"/>
+        <location filename="../src/appearance_dialog.cpp" line="76"/>
+        <source>Success message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/appearance_dialog.cpp" line="79"/>
         <source>Colors</source>
         <translation>Цвета</translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="96"/>
+        <location filename="../src/appearance_dialog.cpp" line="98"/>
         <source>Background:</source>
         <translation>Задний фон</translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="97"/>
+        <location filename="../src/appearance_dialog.cpp" line="99"/>
         <source>Shadow:</source>
         <translation>Тень</translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="98"/>
+        <location filename="../src/appearance_dialog.cpp" line="100"/>
         <source>Highlight:</source>
         <translation>Подсветка</translation>
     </message>
@@ -55,59 +60,59 @@
 <context>
     <name>Board</name>
     <message>
-        <location filename="../src/board.cpp" line="187"/>
-        <location filename="../src/board.cpp" line="293"/>
-        <location filename="../src/board.cpp" line="361"/>
+        <location filename="../src/board.cpp" line="190"/>
+        <location filename="../src/board.cpp" line="301"/>
+        <location filename="../src/board.cpp" line="369"/>
         <source>Error</source>
         <translation>Ошибка</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="187"/>
-        <location filename="../src/board.cpp" line="293"/>
+        <location filename="../src/board.cpp" line="190"/>
+        <location filename="../src/board.cpp" line="301"/>
         <source>Missing image.</source>
         <translation>Изображение отсутствует.</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="194"/>
-        <location filename="../src/board.cpp" line="269"/>
-        <location filename="../src/main.cpp" line="167"/>
+        <location filename="../src/board.cpp" line="197"/>
+        <location filename="../src/board.cpp" line="277"/>
+        <location filename="../src/main.cpp" line="162"/>
         <source>Please Wait</source>
         <translation>Пожалуйста, подождите</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="216"/>
-        <location filename="../src/board.cpp" line="368"/>
+        <location filename="../src/board.cpp" line="219"/>
+        <location filename="../src/board.cpp" line="376"/>
         <source>Loading image...</source>
         <translation>Загрузка изображения...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="222"/>
+        <location filename="../src/board.cpp" line="225"/>
         <source>Generating puzzle...</source>
         <translation>Генерация пазла...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="228"/>
-        <location filename="../src/board.cpp" line="242"/>
+        <location filename="../src/board.cpp" line="236"/>
+        <location filename="../src/board.cpp" line="250"/>
         <source>Creating pieces...</source>
         <translation>Создание пазлов...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="281"/>
+        <location filename="../src/board.cpp" line="289"/>
         <source>Loading puzzle...</source>
         <translation>Загрузка пазла...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="306"/>
+        <location filename="../src/board.cpp" line="314"/>
         <source>Unknown data format</source>
         <translation>Неизвестный формат файла</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="356"/>
+        <location filename="../src/board.cpp" line="364"/>
         <source>Unknown element &apos;%1&apos;</source>
         <translation>Неизвестный элемент &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="361"/>
+        <location filename="../src/board.cpp" line="369"/>
         <source>Error parsing XML file.
 
 %1</source>
@@ -116,22 +121,22 @@
 %1</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="372"/>
+        <location filename="../src/board.cpp" line="380"/>
         <source>Loading pieces...</source>
         <translation>Загрузка пазлов...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="454"/>
+        <location filename="../src/board.cpp" line="462"/>
         <source>Retrieving pieces...</source>
         <translation>Перемешиваем пазлы...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="994"/>
+        <location filename="../src/board.cpp" line="1002"/>
         <source>Placing pieces...</source>
         <translation>Размещение пазлов...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="1326"/>
+        <location filename="../src/board.cpp" line="1331"/>
         <source>Success</source>
         <translation>Успех!</translation>
     </message>
@@ -175,22 +180,22 @@
 <context>
     <name>LocaleDialog</name>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="50"/>
+        <location filename="../src/locale_dialog.cpp" line="52"/>
         <source>Select application language:</source>
         <translation>Выберите язык программы:</translation>
     </message>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="53"/>
+        <location filename="../src/locale_dialog.cpp" line="55"/>
         <source>&lt;System Language&gt;</source>
         <translation>&lt;Язык системы&gt;</translation>
     </message>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="183"/>
+        <location filename="../src/locale_dialog.cpp" line="172"/>
         <source>Note</source>
         <translation>Предупреждение</translation>
     </message>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="183"/>
+        <location filename="../src/locale_dialog.cpp" line="172"/>
         <source>Please restart this application for the change in language to take effect.</source>
         <translation>Пожалуйста, перезапустите программу для того, чтобы изменения вступили в силу.</translation>
     </message>
@@ -198,44 +203,44 @@
 <context>
     <name>NewGameTab</name>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="105"/>
+        <location filename="../src/new_game_tab.cpp" line="106"/>
         <source>Add Image</source>
         <translation>Добавить изображение</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="109"/>
-        <location filename="../src/new_game_tab.cpp" line="290"/>
+        <location filename="../src/new_game_tab.cpp" line="110"/>
+        <location filename="../src/new_game_tab.cpp" line="291"/>
         <source>Remove Image</source>
         <translation>Удалить изображение</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="113"/>
+        <location filename="../src/new_game_tab.cpp" line="114"/>
         <source>Image Properties</source>
         <translation>Настройки изображения</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="132"/>
-        <location filename="../src/new_game_tab.cpp" line="383"/>
+        <location filename="../src/new_game_tab.cpp" line="133"/>
+        <location filename="../src/new_game_tab.cpp" line="384"/>
         <source>%L1 pieces</source>
         <translation>%L1 пазлов</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="193"/>
+        <location filename="../src/new_game_tab.cpp" line="194"/>
         <source>Copying images...</source>
         <translation>Копируем изображения...</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="193"/>
+        <location filename="../src/new_game_tab.cpp" line="194"/>
         <source>Cancel</source>
         <translation>Отмена</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="286"/>
+        <location filename="../src/new_game_tab.cpp" line="287"/>
         <source>Remove selected image?</source>
         <translation>Удалить выбранное изображение?</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="288"/>
+        <location filename="../src/new_game_tab.cpp" line="289"/>
         <source>Remove selected image?
 
 There are saved games using this image that will also be removed.</source>
@@ -244,7 +249,7 @@ There are saved games using this image that will also be removed.</source>
 Сохраненные игры, использующие это изображение, также будут удалены.</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="493"/>
+        <location filename="../src/new_game_tab.cpp" line="494"/>
         <source>Untitled</source>
         <translation>Без названия</translation>
     </message>
@@ -280,7 +285,7 @@ There are saved games using this image that will also be removed.</source>
 <context>
     <name>Overview</name>
     <message>
-        <location filename="../src/overview.cpp" line="38"/>
+        <location filename="../src/overview.cpp" line="39"/>
         <source>Overview</source>
         <translation>Общий вид</translation>
     </message>
@@ -336,215 +341,215 @@ There are saved games using this image that will also be removed.</source>
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/main.cpp" line="168"/>
-        <location filename="../src/window.cpp" line="50"/>
-        <location filename="../src/window.cpp" line="286"/>
+        <location filename="../src/main.cpp" line="56"/>
+        <location filename="../src/main.cpp" line="163"/>
+        <location filename="../src/window.cpp" line="283"/>
         <source>Tetzle</source>
         <translation>Tetzle</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="80"/>
+        <location filename="../src/window.cpp" line="79"/>
         <source>&amp;Game</source>
         <translation>&amp;Игра</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="84"/>
+        <location filename="../src/window.cpp" line="83"/>
         <source>&amp;Retrieve Pieces</source>
         <translation>&amp;Перемешать пазлы</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="84"/>
+        <location filename="../src/window.cpp" line="83"/>
         <source>Ctrl+R</source>
         <translation>Ctrl+R</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="88"/>
+        <location filename="../src/window.cpp" line="87"/>
         <source>&amp;Quit</source>
         <translation>&amp;Выход</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="81"/>
+        <location filename="../src/window.cpp" line="80"/>
         <source>&amp;Choose...</source>
         <translation>&amp;Выбрать...</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="91"/>
+        <location filename="../src/window.cpp" line="90"/>
         <source>&amp;View</source>
         <translation>&amp;Вид</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="92"/>
+        <location filename="../src/window.cpp" line="91"/>
         <source>Zoom &amp;In</source>
         <translation>У&amp;величить</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="92"/>
+        <location filename="../src/window.cpp" line="91"/>
         <source>+</source>
         <translation>+</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="95"/>
+        <location filename="../src/window.cpp" line="94"/>
         <source>Zoom &amp;Out</source>
         <translation>У&amp;меньшить</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="95"/>
+        <location filename="../src/window.cpp" line="94"/>
         <source>-</source>
         <translation>-</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="98"/>
+        <location filename="../src/window.cpp" line="97"/>
         <source>Best &amp;Fit</source>
         <translation>Наилучший вид</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="101"/>
+        <location filename="../src/window.cpp" line="100"/>
         <source>Show O&amp;verview</source>
         <translation>Показывать &amp;общий вид</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="101"/>
+        <location filename="../src/window.cpp" line="100"/>
         <source>Tab</source>
         <translation>Tab</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="107"/>
+        <location filename="../src/window.cpp" line="106"/>
         <source>F&amp;ullscreen</source>
         <translation>&amp;На весь экран</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="111"/>
+        <location filename="../src/window.cpp" line="110"/>
         <source>F11</source>
         <translation>F11</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="113"/>
+        <location filename="../src/window.cpp" line="112"/>
         <source>Ctrl+F</source>
         <translation>Ctrl+F</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="116"/>
+        <location filename="../src/window.cpp" line="115"/>
         <source>&amp;Settings</source>
         <translation>Н&amp;астройки</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="117"/>
+        <location filename="../src/window.cpp" line="116"/>
         <source>&amp;Appearance...</source>
         <translation>&amp;Вид...</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="118"/>
+        <location filename="../src/window.cpp" line="117"/>
         <source>&amp;Language...</source>
         <translation>&amp;Язык...</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="120"/>
+        <location filename="../src/window.cpp" line="119"/>
         <source>&amp;Help</source>
         <translation>&amp;Помощь</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="121"/>
+        <location filename="../src/window.cpp" line="120"/>
         <source>&amp;Controls</source>
         <translation>&amp;Управление</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="123"/>
+        <location filename="../src/window.cpp" line="122"/>
         <source>&amp;About</source>
         <translation>&amp;Об игре</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="125"/>
+        <location filename="../src/window.cpp" line="124"/>
         <source>About &amp;Qt</source>
         <translation>О Qt&amp;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="252"/>
+        <location filename="../src/window.cpp" line="249"/>
         <source>Controls</source>
         <translation>Управление</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="259"/>
+        <location filename="../src/window.cpp" line="256"/>
         <source>&lt;b&gt;Pick Up Pieces:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Брать пазлы:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="260"/>
-        <location filename="../src/window.cpp" line="262"/>
+        <location filename="../src/window.cpp" line="257"/>
+        <location filename="../src/window.cpp" line="259"/>
         <source>Left Click or Space</source>
         <translation>Левый клик или пробел</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="261"/>
+        <location filename="../src/window.cpp" line="258"/>
         <source>&lt;b&gt;Drop Pieces:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Отпускать пазлы:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="263"/>
+        <location filename="../src/window.cpp" line="260"/>
         <source>&lt;b&gt;Select Pieces:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Выделять пазлы&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="264"/>
+        <location filename="../src/window.cpp" line="261"/>
         <source>Left Drag</source>
         <translation>Зажать левую кнопку мыши и выделять</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="265"/>
+        <location filename="../src/window.cpp" line="262"/>
         <source>&lt;b&gt;Rotate Pieces:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Вращение элементов:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="266"/>
+        <location filename="../src/window.cpp" line="263"/>
         <source>Right Click, Control + Left Click, or R</source>
         <translation>Правый клик, Ctrl + левый клик, или R</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="267"/>
+        <location filename="../src/window.cpp" line="264"/>
         <source>&lt;b&gt;Drag Puzzle:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Двигать полотно пазла:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="268"/>
+        <location filename="../src/window.cpp" line="265"/>
         <source>Middle Click, Shift + Left Click, or Arrows</source>
         <translation>Зажать колесико мышки, Shift+ Левый клик, или кнопки Влево, Вправо, Вверх и Вниз</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="269"/>
+        <location filename="../src/window.cpp" line="266"/>
         <source>&lt;b&gt;Zoom Puzzle:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Увеличить пазл:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="270"/>
+        <location filename="../src/window.cpp" line="267"/>
         <source>Scrollwheel or +/-</source>
         <translation>Колесо прокрутки или +/-</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="271"/>
+        <location filename="../src/window.cpp" line="268"/>
         <source>&lt;b&gt;Move Cursor:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Двигать курсор:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="272"/>
+        <location filename="../src/window.cpp" line="269"/>
         <source>Move mouse or W,A,D,S</source>
         <translation>Мышь или W,A,S,D</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="285"/>
+        <location filename="../src/window.cpp" line="282"/>
         <source>About Tetzle</source>
         <translation>О Tetlze</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="287"/>
+        <location filename="../src/window.cpp" line="284"/>
         <source>A jigsaw puzzle with tetrominoes for pieces</source>
         <translation>Игра-головоломка с тетрамино</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="288"/>
+        <location filename="../src/window.cpp" line="285"/>
         <source>Copyright &amp;copy; 2008-%1 Graeme Gott</source>
         <translation>Копирайт &amp;copy; 20080%1 Graeme Gott</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="289"/>
+        <location filename="../src/window.cpp" line="286"/>
         <source>Released under the &lt;a href=%1&gt;GPL 3&lt;/a&gt; license</source>
         <translation>Опубликовано под лицензией &lt;a href=%1&gt;GPL 3&lt;/a&gt;</translation>
     </message>
@@ -552,12 +557,12 @@ There are saved games using this image that will also be removed.</source>
 <context>
     <name>ZoomSlider</name>
     <message>
-        <location filename="../src/zoom_slider.cpp" line="38"/>
+        <location filename="../src/zoom_slider.cpp" line="40"/>
         <source>??%</source>
         <translation>??%</translation>
     </message>
     <message>
-        <location filename="../src/zoom_slider.cpp" line="63"/>
+        <location filename="../src/zoom_slider.cpp" line="65"/>
         <source>%1%</source>
         <translation>%1%</translation>
     </message>

--- a/translations/tetzle_tr.ts
+++ b/translations/tetzle_tr.ts
@@ -4,7 +4,7 @@
 <context>
     <name>AddImage</name>
     <message>
-        <location filename="../src/add_image.cpp" line="87"/>
+        <location filename="../src/add_image.cpp" line="79"/>
         <source>Open Image</source>
         <translation>Resim Aç</translation>
     </message>
@@ -32,22 +32,27 @@
         <translation>Alt gölgeler</translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="77"/>
+        <location filename="../src/appearance_dialog.cpp" line="76"/>
+        <source>Success message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/appearance_dialog.cpp" line="79"/>
         <source>Colors</source>
         <translation>Renkler</translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="96"/>
+        <location filename="../src/appearance_dialog.cpp" line="98"/>
         <source>Background:</source>
         <translation>Arka Plan:</translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="97"/>
+        <location filename="../src/appearance_dialog.cpp" line="99"/>
         <source>Shadow:</source>
         <translation>Gölge:</translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="98"/>
+        <location filename="../src/appearance_dialog.cpp" line="100"/>
         <source>Highlight:</source>
         <translation>Vurgulama:</translation>
     </message>
@@ -55,81 +60,81 @@
 <context>
     <name>Board</name>
     <message>
-        <location filename="../src/board.cpp" line="187"/>
-        <location filename="../src/board.cpp" line="293"/>
-        <location filename="../src/board.cpp" line="361"/>
+        <location filename="../src/board.cpp" line="190"/>
+        <location filename="../src/board.cpp" line="301"/>
+        <location filename="../src/board.cpp" line="369"/>
         <source>Error</source>
         <translation>Hata</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="187"/>
-        <location filename="../src/board.cpp" line="293"/>
+        <location filename="../src/board.cpp" line="190"/>
+        <location filename="../src/board.cpp" line="301"/>
         <source>Missing image.</source>
         <translation>Kayıp resim.</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="194"/>
-        <location filename="../src/board.cpp" line="269"/>
-        <location filename="../src/main.cpp" line="167"/>
+        <location filename="../src/board.cpp" line="197"/>
+        <location filename="../src/board.cpp" line="277"/>
+        <location filename="../src/main.cpp" line="162"/>
         <source>Please Wait</source>
         <translation>Lütfen Bekleyin</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="216"/>
-        <location filename="../src/board.cpp" line="368"/>
+        <location filename="../src/board.cpp" line="219"/>
+        <location filename="../src/board.cpp" line="376"/>
         <source>Loading image...</source>
         <translation>Resim yükleniyor...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="222"/>
+        <location filename="../src/board.cpp" line="225"/>
         <source>Generating puzzle...</source>
         <translation>Yap-boz oluşturuluyor...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="228"/>
-        <location filename="../src/board.cpp" line="242"/>
+        <location filename="../src/board.cpp" line="236"/>
+        <location filename="../src/board.cpp" line="250"/>
         <source>Creating pieces...</source>
         <translation>Parçalar oluşturuluyor...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="281"/>
+        <location filename="../src/board.cpp" line="289"/>
         <source>Loading puzzle...</source>
         <translation>Yap-boz yükleniyor...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="306"/>
+        <location filename="../src/board.cpp" line="314"/>
         <source>Unknown data format</source>
         <translation>Bilinmeyen veri biçimi</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="356"/>
+        <location filename="../src/board.cpp" line="364"/>
         <source>Unknown element &apos;%1&apos;</source>
         <translation>Blinmeyen  &apos;%1&apos; ögesi</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="361"/>
+        <location filename="../src/board.cpp" line="369"/>
         <source>Error parsing XML file.
 
 %1</source>
         <translation>XML dosyası ayrıştırma hatası.⏎ ⏎ %1</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="372"/>
+        <location filename="../src/board.cpp" line="380"/>
         <source>Loading pieces...</source>
         <translation>Parçalar yükleniyor...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="454"/>
+        <location filename="../src/board.cpp" line="462"/>
         <source>Retrieving pieces...</source>
         <translation>Parçalar alınıyor...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="994"/>
+        <location filename="../src/board.cpp" line="1002"/>
         <source>Placing pieces...</source>
         <translation>Parçalar yerleştiriliyor...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="1326"/>
+        <location filename="../src/board.cpp" line="1331"/>
         <source>Success</source>
         <translation>Başarılı</translation>
     </message>
@@ -173,22 +178,22 @@
 <context>
     <name>LocaleDialog</name>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="50"/>
+        <location filename="../src/locale_dialog.cpp" line="52"/>
         <source>Select application language:</source>
         <translation>Uygulama dilini seçin:</translation>
     </message>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="53"/>
+        <location filename="../src/locale_dialog.cpp" line="55"/>
         <source>&lt;System Language&gt;</source>
         <translation>&lt;Sistem Dili&gt;</translation>
     </message>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="183"/>
+        <location filename="../src/locale_dialog.cpp" line="172"/>
         <source>Note</source>
         <translation>Not</translation>
     </message>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="183"/>
+        <location filename="../src/locale_dialog.cpp" line="172"/>
         <source>Please restart this application for the change in language to take effect.</source>
         <translation>Dil değişikliğinin etkin olması için lütfen bu uygulamayı yeniden başlatın.</translation>
     </message>
@@ -196,51 +201,51 @@
 <context>
     <name>NewGameTab</name>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="105"/>
+        <location filename="../src/new_game_tab.cpp" line="106"/>
         <source>Add Image</source>
         <translation>Resim Ekle</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="109"/>
-        <location filename="../src/new_game_tab.cpp" line="290"/>
+        <location filename="../src/new_game_tab.cpp" line="110"/>
+        <location filename="../src/new_game_tab.cpp" line="291"/>
         <source>Remove Image</source>
         <translation>Resim Kaldır</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="113"/>
+        <location filename="../src/new_game_tab.cpp" line="114"/>
         <source>Image Properties</source>
         <translation>Resim Seçenekleri</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="132"/>
-        <location filename="../src/new_game_tab.cpp" line="383"/>
+        <location filename="../src/new_game_tab.cpp" line="133"/>
+        <location filename="../src/new_game_tab.cpp" line="384"/>
         <source>%L1 pieces</source>
         <translation>%L1 parça</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="193"/>
+        <location filename="../src/new_game_tab.cpp" line="194"/>
         <source>Copying images...</source>
         <translation>Resimler kopyalanıyor...</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="193"/>
+        <location filename="../src/new_game_tab.cpp" line="194"/>
         <source>Cancel</source>
         <translation>İptal Et</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="286"/>
+        <location filename="../src/new_game_tab.cpp" line="287"/>
         <source>Remove selected image?</source>
         <translation>Seçilmiş resim kaldırılsın mı?</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="288"/>
+        <location filename="../src/new_game_tab.cpp" line="289"/>
         <source>Remove selected image?
 
 There are saved games using this image that will also be removed.</source>
         <translation>Seçilmiş resim kaldırılsın mı?⏎ ⏎ Bu resmi kullanan kayıtlı oyunlar da kaldırılacaktır.</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="493"/>
+        <location filename="../src/new_game_tab.cpp" line="494"/>
         <source>Untitled</source>
         <translation>Başlıksız</translation>
     </message>
@@ -276,7 +281,7 @@ There are saved games using this image that will also be removed.</source>
 <context>
     <name>Overview</name>
     <message>
-        <location filename="../src/overview.cpp" line="38"/>
+        <location filename="../src/overview.cpp" line="39"/>
         <source>Overview</source>
         <translation>Küçük Resim</translation>
     </message>
@@ -332,215 +337,215 @@ There are saved games using this image that will also be removed.</source>
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/main.cpp" line="168"/>
-        <location filename="../src/window.cpp" line="50"/>
-        <location filename="../src/window.cpp" line="286"/>
+        <location filename="../src/main.cpp" line="56"/>
+        <location filename="../src/main.cpp" line="163"/>
+        <location filename="../src/window.cpp" line="283"/>
         <source>Tetzle</source>
         <translation>Tetzle</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="80"/>
+        <location filename="../src/window.cpp" line="79"/>
         <source>&amp;Game</source>
         <translation>&amp;Oyun</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="84"/>
+        <location filename="../src/window.cpp" line="83"/>
         <source>&amp;Retrieve Pieces</source>
         <translation>&amp;Parçaları Geri Getir</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="84"/>
+        <location filename="../src/window.cpp" line="83"/>
         <source>Ctrl+R</source>
         <translation>Ctrl+R</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="88"/>
+        <location filename="../src/window.cpp" line="87"/>
         <source>&amp;Quit</source>
         <translation>&amp;Çık</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="81"/>
+        <location filename="../src/window.cpp" line="80"/>
         <source>&amp;Choose...</source>
         <translation>&amp;Seç...</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="91"/>
+        <location filename="../src/window.cpp" line="90"/>
         <source>&amp;View</source>
         <translation>&amp;Görünüm</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="92"/>
+        <location filename="../src/window.cpp" line="91"/>
         <source>Zoom &amp;In</source>
         <translation>&amp;Yakınlaş</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="92"/>
+        <location filename="../src/window.cpp" line="91"/>
         <source>+</source>
         <translation>+</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="95"/>
+        <location filename="../src/window.cpp" line="94"/>
         <source>Zoom &amp;Out</source>
         <translation>&amp;Uzaklaş</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="95"/>
+        <location filename="../src/window.cpp" line="94"/>
         <source>-</source>
         <translation>-</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="98"/>
+        <location filename="../src/window.cpp" line="97"/>
         <source>Best &amp;Fit</source>
         <translation>&amp;En Uygun</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="101"/>
+        <location filename="../src/window.cpp" line="100"/>
         <source>Show O&amp;verview</source>
         <translation>&amp;Küçük Resmi Göster</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="101"/>
+        <location filename="../src/window.cpp" line="100"/>
         <source>Tab</source>
         <translation>Sekme</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="107"/>
+        <location filename="../src/window.cpp" line="106"/>
         <source>F&amp;ullscreen</source>
         <translation>&amp;Tam Ekran</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="111"/>
+        <location filename="../src/window.cpp" line="110"/>
         <source>F11</source>
         <translation>F11</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="113"/>
+        <location filename="../src/window.cpp" line="112"/>
         <source>Ctrl+F</source>
         <translation>Ctrl+F</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="116"/>
+        <location filename="../src/window.cpp" line="115"/>
         <source>&amp;Settings</source>
         <translation>&amp;Ayarlar</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="117"/>
+        <location filename="../src/window.cpp" line="116"/>
         <source>&amp;Appearance...</source>
         <translation>&amp;Görünüm...</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="118"/>
+        <location filename="../src/window.cpp" line="117"/>
         <source>&amp;Language...</source>
         <translation>&amp;Dil...</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="120"/>
+        <location filename="../src/window.cpp" line="119"/>
         <source>&amp;Help</source>
         <translation>&amp;Yardım</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="121"/>
+        <location filename="../src/window.cpp" line="120"/>
         <source>&amp;Controls</source>
         <translation>&amp;Kontroller...</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="123"/>
+        <location filename="../src/window.cpp" line="122"/>
         <source>&amp;About</source>
         <translation>&amp;Hakkında</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="125"/>
+        <location filename="../src/window.cpp" line="124"/>
         <source>About &amp;Qt</source>
         <translation>&amp;Qt Hakkında</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="252"/>
+        <location filename="../src/window.cpp" line="249"/>
         <source>Controls</source>
         <translation>Kontroller</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="259"/>
+        <location filename="../src/window.cpp" line="256"/>
         <source>&lt;b&gt;Pick Up Pieces:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Parçaları Al:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="260"/>
-        <location filename="../src/window.cpp" line="262"/>
+        <location filename="../src/window.cpp" line="257"/>
+        <location filename="../src/window.cpp" line="259"/>
         <source>Left Click or Space</source>
         <translation>Sol Tıklama ya da Boşluk</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="261"/>
+        <location filename="../src/window.cpp" line="258"/>
         <source>&lt;b&gt;Drop Pieces:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Parçaları Bırak:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="263"/>
+        <location filename="../src/window.cpp" line="260"/>
         <source>&lt;b&gt;Select Pieces:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Parçaları Seç:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="264"/>
+        <location filename="../src/window.cpp" line="261"/>
         <source>Left Drag</source>
         <translation>Sol Sürükleme</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="265"/>
+        <location filename="../src/window.cpp" line="262"/>
         <source>&lt;b&gt;Rotate Pieces:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Parçaları Döndür:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="266"/>
+        <location filename="../src/window.cpp" line="263"/>
         <source>Right Click, Control + Left Click, or R</source>
         <translation>Sağ Tıklama, Ctrl + Sol Tıklama ya da R</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="267"/>
+        <location filename="../src/window.cpp" line="264"/>
         <source>&lt;b&gt;Drag Puzzle:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Yap-bozu Sürükle:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="268"/>
+        <location filename="../src/window.cpp" line="265"/>
         <source>Middle Click, Shift + Left Click, or Arrows</source>
         <translation>Orta Tıklama, Shift + Sol Tıklama ya da Oklar</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="269"/>
+        <location filename="../src/window.cpp" line="266"/>
         <source>&lt;b&gt;Zoom Puzzle:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Yap-boz Yakınlaş/Uzaklaş:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="270"/>
+        <location filename="../src/window.cpp" line="267"/>
         <source>Scrollwheel or +/-</source>
         <translation>Tekerleği çevir ya da +/-</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="271"/>
+        <location filename="../src/window.cpp" line="268"/>
         <source>&lt;b&gt;Move Cursor:&lt;/b&gt;</source>
         <translation>&lt;b&gt;İmleci Hareket Ettir:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="272"/>
+        <location filename="../src/window.cpp" line="269"/>
         <source>Move mouse or W,A,D,S</source>
         <translation>Fare ya da W, A, S, D</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="285"/>
+        <location filename="../src/window.cpp" line="282"/>
         <source>About Tetzle</source>
         <translation>Tetzle Hakkında</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="287"/>
+        <location filename="../src/window.cpp" line="284"/>
         <source>A jigsaw puzzle with tetrominoes for pieces</source>
         <translation>Tetris benzeri parçalı bir yap-boz oyunu</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="288"/>
+        <location filename="../src/window.cpp" line="285"/>
         <source>Copyright &amp;copy; 2008-%1 Graeme Gott</source>
         <translation>Telif hakları saklıdır &amp;copy; 2008-%1 Graeme Gott</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="289"/>
+        <location filename="../src/window.cpp" line="286"/>
         <source>Released under the &lt;a href=%1&gt;GPL 3&lt;/a&gt; license</source>
         <translation>&lt;a href=%1&gt;GPL 3&lt;/a&gt; lisansı altında yayınlanmıştır</translation>
     </message>
@@ -548,12 +553,12 @@ There are saved games using this image that will also be removed.</source>
 <context>
     <name>ZoomSlider</name>
     <message>
-        <location filename="../src/zoom_slider.cpp" line="38"/>
+        <location filename="../src/zoom_slider.cpp" line="40"/>
         <source>??%</source>
         <translation>??%</translation>
     </message>
     <message>
-        <location filename="../src/zoom_slider.cpp" line="63"/>
+        <location filename="../src/zoom_slider.cpp" line="65"/>
         <source>%1%</source>
         <translation>%1%</translation>
     </message>

--- a/translations/tetzle_uk.ts
+++ b/translations/tetzle_uk.ts
@@ -4,7 +4,7 @@
 <context>
     <name>AddImage</name>
     <message>
-        <location filename="../src/add_image.cpp" line="87"/>
+        <location filename="../src/add_image.cpp" line="79"/>
         <source>Open Image</source>
         <translation>Відкрити зображення</translation>
     </message>
@@ -32,22 +32,27 @@
         <translation>Різкі тіні</translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="77"/>
+        <location filename="../src/appearance_dialog.cpp" line="76"/>
+        <source>Success message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/appearance_dialog.cpp" line="79"/>
         <source>Colors</source>
         <translation>Колір</translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="96"/>
+        <location filename="../src/appearance_dialog.cpp" line="98"/>
         <source>Background:</source>
         <translation>Фон:</translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="97"/>
+        <location filename="../src/appearance_dialog.cpp" line="99"/>
         <source>Shadow:</source>
         <translation>Тінь:</translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="98"/>
+        <location filename="../src/appearance_dialog.cpp" line="100"/>
         <source>Highlight:</source>
         <translation>Підсвічування:</translation>
     </message>
@@ -55,59 +60,59 @@
 <context>
     <name>Board</name>
     <message>
-        <location filename="../src/board.cpp" line="187"/>
-        <location filename="../src/board.cpp" line="293"/>
-        <location filename="../src/board.cpp" line="361"/>
+        <location filename="../src/board.cpp" line="190"/>
+        <location filename="../src/board.cpp" line="301"/>
+        <location filename="../src/board.cpp" line="369"/>
         <source>Error</source>
         <translation>Помилка</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="187"/>
-        <location filename="../src/board.cpp" line="293"/>
+        <location filename="../src/board.cpp" line="190"/>
+        <location filename="../src/board.cpp" line="301"/>
         <source>Missing image.</source>
         <translation>Зображення немає.</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="194"/>
-        <location filename="../src/board.cpp" line="269"/>
-        <location filename="../src/main.cpp" line="167"/>
+        <location filename="../src/board.cpp" line="197"/>
+        <location filename="../src/board.cpp" line="277"/>
+        <location filename="../src/main.cpp" line="162"/>
         <source>Please Wait</source>
         <translation>Будь ласка, зачекайте</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="216"/>
-        <location filename="../src/board.cpp" line="368"/>
+        <location filename="../src/board.cpp" line="219"/>
+        <location filename="../src/board.cpp" line="376"/>
         <source>Loading image...</source>
         <translation>Завантаження зображення...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="222"/>
+        <location filename="../src/board.cpp" line="225"/>
         <source>Generating puzzle...</source>
         <translation>Генерування пазла...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="228"/>
-        <location filename="../src/board.cpp" line="242"/>
+        <location filename="../src/board.cpp" line="236"/>
+        <location filename="../src/board.cpp" line="250"/>
         <source>Creating pieces...</source>
         <translation>Створення елементів...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="281"/>
+        <location filename="../src/board.cpp" line="289"/>
         <source>Loading puzzle...</source>
         <translation>Завантаження пазла...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="306"/>
+        <location filename="../src/board.cpp" line="314"/>
         <source>Unknown data format</source>
         <translation>Невідомий формат даних</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="356"/>
+        <location filename="../src/board.cpp" line="364"/>
         <source>Unknown element &apos;%1&apos;</source>
         <translation>Невідомий елемент «%1»</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="361"/>
+        <location filename="../src/board.cpp" line="369"/>
         <source>Error parsing XML file.
 
 %1</source>
@@ -116,22 +121,22 @@
 %1</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="372"/>
+        <location filename="../src/board.cpp" line="380"/>
         <source>Loading pieces...</source>
         <translation>Завантаження елементів...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="454"/>
+        <location filename="../src/board.cpp" line="462"/>
         <source>Retrieving pieces...</source>
         <translation>Отримання елементів...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="994"/>
+        <location filename="../src/board.cpp" line="1002"/>
         <source>Placing pieces...</source>
         <translation>Розташування елементів...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="1326"/>
+        <location filename="../src/board.cpp" line="1331"/>
         <source>Success</source>
         <translation>Успішно</translation>
     </message>
@@ -175,22 +180,22 @@
 <context>
     <name>LocaleDialog</name>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="50"/>
+        <location filename="../src/locale_dialog.cpp" line="52"/>
         <source>Select application language:</source>
         <translation>Вибрати мову програми:</translation>
     </message>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="53"/>
+        <location filename="../src/locale_dialog.cpp" line="55"/>
         <source>&lt;System Language&gt;</source>
         <translation>&lt;Системна мова&gt;</translation>
     </message>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="183"/>
+        <location filename="../src/locale_dialog.cpp" line="172"/>
         <source>Note</source>
         <translation>Нотатка</translation>
     </message>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="183"/>
+        <location filename="../src/locale_dialog.cpp" line="172"/>
         <source>Please restart this application for the change in language to take effect.</source>
         <translation>Перезапустіть програму, щоб зміна мови набула сили.</translation>
     </message>
@@ -198,44 +203,44 @@
 <context>
     <name>NewGameTab</name>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="105"/>
+        <location filename="../src/new_game_tab.cpp" line="106"/>
         <source>Add Image</source>
         <translation>Додати зображення</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="109"/>
-        <location filename="../src/new_game_tab.cpp" line="290"/>
+        <location filename="../src/new_game_tab.cpp" line="110"/>
+        <location filename="../src/new_game_tab.cpp" line="291"/>
         <source>Remove Image</source>
         <translation>Вилучити зображення</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="113"/>
+        <location filename="../src/new_game_tab.cpp" line="114"/>
         <source>Image Properties</source>
         <translation>Властивості зображення</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="132"/>
-        <location filename="../src/new_game_tab.cpp" line="383"/>
+        <location filename="../src/new_game_tab.cpp" line="133"/>
+        <location filename="../src/new_game_tab.cpp" line="384"/>
         <source>%L1 pieces</source>
         <translation>%L1 елементів</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="193"/>
+        <location filename="../src/new_game_tab.cpp" line="194"/>
         <source>Copying images...</source>
         <translation>Копіювання зображень...</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="193"/>
+        <location filename="../src/new_game_tab.cpp" line="194"/>
         <source>Cancel</source>
         <translation>Скасувати</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="286"/>
+        <location filename="../src/new_game_tab.cpp" line="287"/>
         <source>Remove selected image?</source>
         <translation>Вилучити вибране зображення?</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="288"/>
+        <location filename="../src/new_game_tab.cpp" line="289"/>
         <source>Remove selected image?
 
 There are saved games using this image that will also be removed.</source>
@@ -244,7 +249,7 @@ There are saved games using this image that will also be removed.</source>
 Є збережені ігри з таким зображенням, що також будуть вилучені.</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="493"/>
+        <location filename="../src/new_game_tab.cpp" line="494"/>
         <source>Untitled</source>
         <translation>Без назви</translation>
     </message>
@@ -280,7 +285,7 @@ There are saved games using this image that will also be removed.</source>
 <context>
     <name>Overview</name>
     <message>
-        <location filename="../src/overview.cpp" line="38"/>
+        <location filename="../src/overview.cpp" line="39"/>
         <source>Overview</source>
         <translation>Огляд</translation>
     </message>
@@ -336,215 +341,215 @@ There are saved games using this image that will also be removed.</source>
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/main.cpp" line="168"/>
-        <location filename="../src/window.cpp" line="50"/>
-        <location filename="../src/window.cpp" line="286"/>
+        <location filename="../src/main.cpp" line="56"/>
+        <location filename="../src/main.cpp" line="163"/>
+        <location filename="../src/window.cpp" line="283"/>
         <source>Tetzle</source>
         <translation>Tetzle</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="80"/>
+        <location filename="../src/window.cpp" line="79"/>
         <source>&amp;Game</source>
         <translation>&amp;Гра</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="84"/>
+        <location filename="../src/window.cpp" line="83"/>
         <source>&amp;Retrieve Pieces</source>
         <translation>&amp;Отримати елементи</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="84"/>
+        <location filename="../src/window.cpp" line="83"/>
         <source>Ctrl+R</source>
         <translation>Ctrl+R</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="88"/>
+        <location filename="../src/window.cpp" line="87"/>
         <source>&amp;Quit</source>
         <translation>&amp;Вийти</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="81"/>
+        <location filename="../src/window.cpp" line="80"/>
         <source>&amp;Choose...</source>
         <translation>&amp;Вибрати...</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="91"/>
+        <location filename="../src/window.cpp" line="90"/>
         <source>&amp;View</source>
         <translation>&amp;Перегляд</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="92"/>
+        <location filename="../src/window.cpp" line="91"/>
         <source>Zoom &amp;In</source>
         <translation>&amp;Збільшити</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="92"/>
+        <location filename="../src/window.cpp" line="91"/>
         <source>+</source>
         <translation>+</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="95"/>
+        <location filename="../src/window.cpp" line="94"/>
         <source>Zoom &amp;Out</source>
         <translation>Зм&amp;еншити</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="95"/>
+        <location filename="../src/window.cpp" line="94"/>
         <source>-</source>
         <translation>-</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="98"/>
+        <location filename="../src/window.cpp" line="97"/>
         <source>Best &amp;Fit</source>
         <translation>Найкращий &amp;добір</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="101"/>
+        <location filename="../src/window.cpp" line="100"/>
         <source>Show O&amp;verview</source>
         <translation>Показати о&amp;гляд</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="101"/>
+        <location filename="../src/window.cpp" line="100"/>
         <source>Tab</source>
         <translation>Tab</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="107"/>
+        <location filename="../src/window.cpp" line="106"/>
         <source>F&amp;ullscreen</source>
         <translation>На по&amp;вний екран</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="111"/>
+        <location filename="../src/window.cpp" line="110"/>
         <source>F11</source>
         <translation>F11</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="113"/>
+        <location filename="../src/window.cpp" line="112"/>
         <source>Ctrl+F</source>
         <translation>Ctrl+F</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="116"/>
+        <location filename="../src/window.cpp" line="115"/>
         <source>&amp;Settings</source>
         <translation>&amp;Параметри</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="117"/>
+        <location filename="../src/window.cpp" line="116"/>
         <source>&amp;Appearance...</source>
         <translation>&amp;Вигляд...</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="118"/>
+        <location filename="../src/window.cpp" line="117"/>
         <source>&amp;Language...</source>
         <translation>&amp;Мова...</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="120"/>
+        <location filename="../src/window.cpp" line="119"/>
         <source>&amp;Help</source>
         <translation>&amp;Довідка</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="121"/>
+        <location filename="../src/window.cpp" line="120"/>
         <source>&amp;Controls</source>
         <translation>&amp;Керування</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="123"/>
+        <location filename="../src/window.cpp" line="122"/>
         <source>&amp;About</source>
         <translation>Пр&amp;о гру</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="125"/>
+        <location filename="../src/window.cpp" line="124"/>
         <source>About &amp;Qt</source>
         <translation>Про &amp;Qt</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="252"/>
+        <location filename="../src/window.cpp" line="249"/>
         <source>Controls</source>
         <translation>Керування</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="259"/>
+        <location filename="../src/window.cpp" line="256"/>
         <source>&lt;b&gt;Pick Up Pieces:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Підняти елементи:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="260"/>
-        <location filename="../src/window.cpp" line="262"/>
+        <location filename="../src/window.cpp" line="257"/>
+        <location filename="../src/window.cpp" line="259"/>
         <source>Left Click or Space</source>
         <translation>Ліва кнопка миші або пробіл</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="261"/>
+        <location filename="../src/window.cpp" line="258"/>
         <source>&lt;b&gt;Drop Pieces:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Опустити елементи:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="263"/>
+        <location filename="../src/window.cpp" line="260"/>
         <source>&lt;b&gt;Select Pieces:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Вибрати елементи:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="264"/>
+        <location filename="../src/window.cpp" line="261"/>
         <source>Left Drag</source>
         <translation>Перетягування лівою кнопкою</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="265"/>
+        <location filename="../src/window.cpp" line="262"/>
         <source>&lt;b&gt;Rotate Pieces:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Обернути елементи:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="266"/>
+        <location filename="../src/window.cpp" line="263"/>
         <source>Right Click, Control + Left Click, or R</source>
         <translation>Права кнопка миші, Ctrl + ліва кнопка або R</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="267"/>
+        <location filename="../src/window.cpp" line="264"/>
         <source>&lt;b&gt;Drag Puzzle:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Перетягти пазл:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="268"/>
+        <location filename="../src/window.cpp" line="265"/>
         <source>Middle Click, Shift + Left Click, or Arrows</source>
         <translation>Середня кнопка, Shift + ліва кнопка або стрілки</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="269"/>
+        <location filename="../src/window.cpp" line="266"/>
         <source>&lt;b&gt;Zoom Puzzle:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Масштаб пазла:&lt;/b&gt; </translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="270"/>
+        <location filename="../src/window.cpp" line="267"/>
         <source>Scrollwheel or +/-</source>
         <translation>Колесо миші або +/-</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="271"/>
+        <location filename="../src/window.cpp" line="268"/>
         <source>&lt;b&gt;Move Cursor:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Перемістити курсор:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="272"/>
+        <location filename="../src/window.cpp" line="269"/>
         <source>Move mouse or W,A,D,S</source>
         <translation>Перемістити мишу або клавіші W, A, D, S</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="285"/>
+        <location filename="../src/window.cpp" line="282"/>
         <source>About Tetzle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="287"/>
+        <location filename="../src/window.cpp" line="284"/>
         <source>A jigsaw puzzle with tetrominoes for pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="288"/>
+        <location filename="../src/window.cpp" line="285"/>
         <source>Copyright &amp;copy; 2008-%1 Graeme Gott</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="289"/>
+        <location filename="../src/window.cpp" line="286"/>
         <source>Released under the &lt;a href=%1&gt;GPL 3&lt;/a&gt; license</source>
         <translation type="unfinished"></translation>
     </message>
@@ -552,12 +557,12 @@ There are saved games using this image that will also be removed.</source>
 <context>
     <name>ZoomSlider</name>
     <message>
-        <location filename="../src/zoom_slider.cpp" line="38"/>
+        <location filename="../src/zoom_slider.cpp" line="40"/>
         <source>??%</source>
         <translation>??%</translation>
     </message>
     <message>
-        <location filename="../src/zoom_slider.cpp" line="63"/>
+        <location filename="../src/zoom_slider.cpp" line="65"/>
         <source>%1%</source>
         <translation>%1%</translation>
     </message>

--- a/translations/tetzle_uk_UA.ts
+++ b/translations/tetzle_uk_UA.ts
@@ -4,7 +4,7 @@
 <context>
     <name>AddImage</name>
     <message>
-        <location filename="../src/add_image.cpp" line="87"/>
+        <location filename="../src/add_image.cpp" line="79"/>
         <source>Open Image</source>
         <translation>Відкрити зображення</translation>
     </message>
@@ -32,22 +32,27 @@
         <translation>Різкі тіні</translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="77"/>
+        <location filename="../src/appearance_dialog.cpp" line="76"/>
+        <source>Success message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/appearance_dialog.cpp" line="79"/>
         <source>Colors</source>
         <translation>Колір</translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="96"/>
+        <location filename="../src/appearance_dialog.cpp" line="98"/>
         <source>Background:</source>
         <translation>Фон:</translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="97"/>
+        <location filename="../src/appearance_dialog.cpp" line="99"/>
         <source>Shadow:</source>
         <translation>Тінь:</translation>
     </message>
     <message>
-        <location filename="../src/appearance_dialog.cpp" line="98"/>
+        <location filename="../src/appearance_dialog.cpp" line="100"/>
         <source>Highlight:</source>
         <translation>Підсвічування:</translation>
     </message>
@@ -55,59 +60,59 @@
 <context>
     <name>Board</name>
     <message>
-        <location filename="../src/board.cpp" line="187"/>
-        <location filename="../src/board.cpp" line="293"/>
-        <location filename="../src/board.cpp" line="361"/>
+        <location filename="../src/board.cpp" line="190"/>
+        <location filename="../src/board.cpp" line="301"/>
+        <location filename="../src/board.cpp" line="369"/>
         <source>Error</source>
         <translation>Помилка</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="187"/>
-        <location filename="../src/board.cpp" line="293"/>
+        <location filename="../src/board.cpp" line="190"/>
+        <location filename="../src/board.cpp" line="301"/>
         <source>Missing image.</source>
         <translation>Зображення немає.</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="194"/>
-        <location filename="../src/board.cpp" line="269"/>
-        <location filename="../src/main.cpp" line="167"/>
+        <location filename="../src/board.cpp" line="197"/>
+        <location filename="../src/board.cpp" line="277"/>
+        <location filename="../src/main.cpp" line="162"/>
         <source>Please Wait</source>
         <translation>Будь ласка, зачекайте</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="216"/>
-        <location filename="../src/board.cpp" line="368"/>
+        <location filename="../src/board.cpp" line="219"/>
+        <location filename="../src/board.cpp" line="376"/>
         <source>Loading image...</source>
         <translation>Завантаження зображення...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="222"/>
+        <location filename="../src/board.cpp" line="225"/>
         <source>Generating puzzle...</source>
         <translation>Генерування пазлу...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="228"/>
-        <location filename="../src/board.cpp" line="242"/>
+        <location filename="../src/board.cpp" line="236"/>
+        <location filename="../src/board.cpp" line="250"/>
         <source>Creating pieces...</source>
         <translation>Створення елементів...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="281"/>
+        <location filename="../src/board.cpp" line="289"/>
         <source>Loading puzzle...</source>
         <translation>Завантаження пазлу...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="306"/>
+        <location filename="../src/board.cpp" line="314"/>
         <source>Unknown data format</source>
         <translation>Невідомий формат даних</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="356"/>
+        <location filename="../src/board.cpp" line="364"/>
         <source>Unknown element &apos;%1&apos;</source>
         <translation>Невідомий елемент &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="361"/>
+        <location filename="../src/board.cpp" line="369"/>
         <source>Error parsing XML file.
 
 %1</source>
@@ -116,22 +121,22 @@
 %1</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="372"/>
+        <location filename="../src/board.cpp" line="380"/>
         <source>Loading pieces...</source>
         <translation>Завантаження елементів...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="454"/>
+        <location filename="../src/board.cpp" line="462"/>
         <source>Retrieving pieces...</source>
         <translation>Отримання елементів...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="994"/>
+        <location filename="../src/board.cpp" line="1002"/>
         <source>Placing pieces...</source>
         <translation>Розташування елементів...</translation>
     </message>
     <message>
-        <location filename="../src/board.cpp" line="1326"/>
+        <location filename="../src/board.cpp" line="1331"/>
         <source>Success</source>
         <translation>Успішно</translation>
     </message>
@@ -175,22 +180,22 @@
 <context>
     <name>LocaleDialog</name>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="50"/>
+        <location filename="../src/locale_dialog.cpp" line="52"/>
         <source>Select application language:</source>
         <translation>Вибрати мову програми:</translation>
     </message>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="53"/>
+        <location filename="../src/locale_dialog.cpp" line="55"/>
         <source>&lt;System Language&gt;</source>
         <translation>&lt;Системна мова&gt;</translation>
     </message>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="183"/>
+        <location filename="../src/locale_dialog.cpp" line="172"/>
         <source>Note</source>
         <translation>Нотатка</translation>
     </message>
     <message>
-        <location filename="../src/locale_dialog.cpp" line="183"/>
+        <location filename="../src/locale_dialog.cpp" line="172"/>
         <source>Please restart this application for the change in language to take effect.</source>
         <translation>Перезапустіть програму, щоб зміна мови набула сили.</translation>
     </message>
@@ -198,44 +203,44 @@
 <context>
     <name>NewGameTab</name>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="105"/>
+        <location filename="../src/new_game_tab.cpp" line="106"/>
         <source>Add Image</source>
         <translation>Додати зображення</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="109"/>
-        <location filename="../src/new_game_tab.cpp" line="290"/>
+        <location filename="../src/new_game_tab.cpp" line="110"/>
+        <location filename="../src/new_game_tab.cpp" line="291"/>
         <source>Remove Image</source>
         <translation>Вилучити зображення</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="113"/>
+        <location filename="../src/new_game_tab.cpp" line="114"/>
         <source>Image Properties</source>
         <translation>Властивості зображення</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="132"/>
-        <location filename="../src/new_game_tab.cpp" line="383"/>
+        <location filename="../src/new_game_tab.cpp" line="133"/>
+        <location filename="../src/new_game_tab.cpp" line="384"/>
         <source>%L1 pieces</source>
         <translation>%L1 елементів</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="193"/>
+        <location filename="../src/new_game_tab.cpp" line="194"/>
         <source>Copying images...</source>
         <translation>Копіювання зображень...</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="193"/>
+        <location filename="../src/new_game_tab.cpp" line="194"/>
         <source>Cancel</source>
         <translation>Скасувати</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="286"/>
+        <location filename="../src/new_game_tab.cpp" line="287"/>
         <source>Remove selected image?</source>
         <translation>Вилучити вибране зображення?</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="288"/>
+        <location filename="../src/new_game_tab.cpp" line="289"/>
         <source>Remove selected image?
 
 There are saved games using this image that will also be removed.</source>
@@ -244,7 +249,7 @@ There are saved games using this image that will also be removed.</source>
 Є збережені ігри з таким зображенням, що також будуть вилучені.</translation>
     </message>
     <message>
-        <location filename="../src/new_game_tab.cpp" line="493"/>
+        <location filename="../src/new_game_tab.cpp" line="494"/>
         <source>Untitled</source>
         <translation>Без назви</translation>
     </message>
@@ -280,7 +285,7 @@ There are saved games using this image that will also be removed.</source>
 <context>
     <name>Overview</name>
     <message>
-        <location filename="../src/overview.cpp" line="38"/>
+        <location filename="../src/overview.cpp" line="39"/>
         <source>Overview</source>
         <translation>Огляд</translation>
     </message>
@@ -336,215 +341,215 @@ There are saved games using this image that will also be removed.</source>
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/main.cpp" line="168"/>
-        <location filename="../src/window.cpp" line="50"/>
-        <location filename="../src/window.cpp" line="286"/>
+        <location filename="../src/main.cpp" line="56"/>
+        <location filename="../src/main.cpp" line="163"/>
+        <location filename="../src/window.cpp" line="283"/>
         <source>Tetzle</source>
         <translation>Tetzle</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="80"/>
+        <location filename="../src/window.cpp" line="79"/>
         <source>&amp;Game</source>
         <translation>&amp;Гра</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="84"/>
+        <location filename="../src/window.cpp" line="83"/>
         <source>&amp;Retrieve Pieces</source>
         <translation>&amp;Отримати елементи</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="84"/>
+        <location filename="../src/window.cpp" line="83"/>
         <source>Ctrl+R</source>
         <translation>Ctrl+R</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="88"/>
+        <location filename="../src/window.cpp" line="87"/>
         <source>&amp;Quit</source>
         <translation>&amp;Вийти</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="81"/>
+        <location filename="../src/window.cpp" line="80"/>
         <source>&amp;Choose...</source>
         <translation>&amp;Вибрати...</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="91"/>
+        <location filename="../src/window.cpp" line="90"/>
         <source>&amp;View</source>
         <translation>&amp;Вигляд</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="92"/>
+        <location filename="../src/window.cpp" line="91"/>
         <source>Zoom &amp;In</source>
         <translation>&amp;Збільшити</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="92"/>
+        <location filename="../src/window.cpp" line="91"/>
         <source>+</source>
         <translation>+</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="95"/>
+        <location filename="../src/window.cpp" line="94"/>
         <source>Zoom &amp;Out</source>
         <translation>Зм&amp;еншити</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="95"/>
+        <location filename="../src/window.cpp" line="94"/>
         <source>-</source>
         <translation>-</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="98"/>
+        <location filename="../src/window.cpp" line="97"/>
         <source>Best &amp;Fit</source>
         <translation>Найкращий &amp;добір</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="101"/>
+        <location filename="../src/window.cpp" line="100"/>
         <source>Show O&amp;verview</source>
         <translation>Показати о&amp;гляд</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="101"/>
+        <location filename="../src/window.cpp" line="100"/>
         <source>Tab</source>
         <translation>Tab</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="107"/>
+        <location filename="../src/window.cpp" line="106"/>
         <source>F&amp;ullscreen</source>
         <translation>На по&amp;вний екран</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="111"/>
+        <location filename="../src/window.cpp" line="110"/>
         <source>F11</source>
         <translation>F11</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="113"/>
+        <location filename="../src/window.cpp" line="112"/>
         <source>Ctrl+F</source>
         <translation>Ctrl+F</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="116"/>
+        <location filename="../src/window.cpp" line="115"/>
         <source>&amp;Settings</source>
         <translation>&amp;Налаштування</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="117"/>
+        <location filename="../src/window.cpp" line="116"/>
         <source>&amp;Appearance...</source>
         <translation>&amp;Вигляд...</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="118"/>
+        <location filename="../src/window.cpp" line="117"/>
         <source>&amp;Language...</source>
         <translation>&amp;Мова...</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="120"/>
+        <location filename="../src/window.cpp" line="119"/>
         <source>&amp;Help</source>
         <translation>&amp;Довідка</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="121"/>
+        <location filename="../src/window.cpp" line="120"/>
         <source>&amp;Controls</source>
         <translation>&amp;Керування</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="123"/>
+        <location filename="../src/window.cpp" line="122"/>
         <source>&amp;About</source>
         <translation>Пр&amp;о гру</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="125"/>
+        <location filename="../src/window.cpp" line="124"/>
         <source>About &amp;Qt</source>
         <translation>Про &amp;Qt</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="252"/>
+        <location filename="../src/window.cpp" line="249"/>
         <source>Controls</source>
         <translation>Керування</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="259"/>
+        <location filename="../src/window.cpp" line="256"/>
         <source>&lt;b&gt;Pick Up Pieces:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Підняти елементи:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="260"/>
-        <location filename="../src/window.cpp" line="262"/>
+        <location filename="../src/window.cpp" line="257"/>
+        <location filename="../src/window.cpp" line="259"/>
         <source>Left Click or Space</source>
         <translation>Ліва кнопка миші або пробіл</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="261"/>
+        <location filename="../src/window.cpp" line="258"/>
         <source>&lt;b&gt;Drop Pieces:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Опустити елементи:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="263"/>
+        <location filename="../src/window.cpp" line="260"/>
         <source>&lt;b&gt;Select Pieces:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Вибрати елементи:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="264"/>
+        <location filename="../src/window.cpp" line="261"/>
         <source>Left Drag</source>
         <translation>Ліве перетягування</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="265"/>
+        <location filename="../src/window.cpp" line="262"/>
         <source>&lt;b&gt;Rotate Pieces:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Обернути елементи:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="266"/>
+        <location filename="../src/window.cpp" line="263"/>
         <source>Right Click, Control + Left Click, or R</source>
         <translation>Права кнопка миші, Ctrl + ліва кнопка або R</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="267"/>
+        <location filename="../src/window.cpp" line="264"/>
         <source>&lt;b&gt;Drag Puzzle:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Перетягти пазл:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="268"/>
+        <location filename="../src/window.cpp" line="265"/>
         <source>Middle Click, Shift + Left Click, or Arrows</source>
         <translation>Середня кнопка, Shift + ліва кнопка або стрілки</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="269"/>
+        <location filename="../src/window.cpp" line="266"/>
         <source>&lt;b&gt;Zoom Puzzle:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Масштабувати пазл:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="270"/>
+        <location filename="../src/window.cpp" line="267"/>
         <source>Scrollwheel or +/-</source>
         <translation>Колесо миші або +/-</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="271"/>
+        <location filename="../src/window.cpp" line="268"/>
         <source>&lt;b&gt;Move Cursor:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Перемістити курсор:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="272"/>
+        <location filename="../src/window.cpp" line="269"/>
         <source>Move mouse or W,A,D,S</source>
         <translation>Перемістити мишу або W, A, D, S</translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="285"/>
+        <location filename="../src/window.cpp" line="282"/>
         <source>About Tetzle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="287"/>
+        <location filename="../src/window.cpp" line="284"/>
         <source>A jigsaw puzzle with tetrominoes for pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="288"/>
+        <location filename="../src/window.cpp" line="285"/>
         <source>Copyright &amp;copy; 2008-%1 Graeme Gott</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/window.cpp" line="289"/>
+        <location filename="../src/window.cpp" line="286"/>
         <source>Released under the &lt;a href=%1&gt;GPL 3&lt;/a&gt; license</source>
         <translation type="unfinished"></translation>
     </message>
@@ -552,12 +557,12 @@ There are saved games using this image that will also be removed.</source>
 <context>
     <name>ZoomSlider</name>
     <message>
-        <location filename="../src/zoom_slider.cpp" line="38"/>
+        <location filename="../src/zoom_slider.cpp" line="40"/>
         <source>??%</source>
         <translation>??%</translation>
     </message>
     <message>
-        <location filename="../src/zoom_slider.cpp" line="63"/>
+        <location filename="../src/zoom_slider.cpp" line="65"/>
         <source>%1%</source>
         <translation>%1%</translation>
     </message>


### PR DESCRIPTION
Changes I made were:
* stop input lag with Qt5 by changing calls to updateGL into update
* add the option to suppress the success message, so that finished puzzles can be seen. The idea is that some users may feel that seeing the image is a better reward for finishing it than a success message. This feature is disabled by default, to mirror the existing behavior.
* update translations to mirror new code positions